### PR TITLE
chore: sort import statements

### DIFF
--- a/bindings/ast/canonicalize_test.go
+++ b/bindings/ast/canonicalize_test.go
@@ -6,8 +6,9 @@ import (
 	"path"
 	"testing"
 
-	"github.com/kroma-network/kroma/bindings/solc"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kroma-network/kroma/bindings/solc"
 )
 
 type astIDTest struct {

--- a/bindings/hardhat/hardhat_test.go
+++ b/bindings/hardhat/hardhat_test.go
@@ -3,9 +3,9 @@ package hardhat_test
 import (
 	"testing"
 
-	"github.com/kroma-network/kroma/bindings/hardhat"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/kroma-network/kroma/bindings/hardhat"
 )
 
 func TestGetFullyQualifiedName(t *testing.T) {

--- a/bindings/hardhat/types.go
+++ b/bindings/hardhat/types.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/kroma-network/kroma/bindings/solc"
 )
 

--- a/bindings/predeploys/addresses_test.go
+++ b/bindings/predeploys/addresses_test.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/kroma-network/kroma/bindings/bindings"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kroma-network/kroma/bindings/bindings"
 )
 
 func TestGethAddresses(t *testing.T) {

--- a/components/node/eth/account_proof.go
+++ b/components/node/eth/account_proof.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
-
 	zktrie "github.com/kroma-network/zktrie/trie"
 	zkt "github.com/kroma-network/zktrie/types"
 )

--- a/components/node/eth/ssz_test.go
+++ b/components/node/eth/ssz_test.go
@@ -6,10 +6,9 @@ import (
 	"math"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 // FuzzExecutionPayloadUnmarshal checks that our SSZ decoding never panics

--- a/components/node/p2p/rpc_api.go
+++ b/components/node/p2p/rpc_api.go
@@ -5,10 +5,9 @@ import (
 	"net"
 	"time"
 
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-
-	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
 type PeerInfo struct {

--- a/components/node/rollup/derive/frame_test.go
+++ b/components/node/rollup/derive/frame_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kroma-network/kroma/components/node/testutils"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kroma-network/kroma/components/node/testutils"
 )
 
 func FuzzFrameUnmarshalBinary(f *testing.F) {

--- a/components/node/withdrawals/proof.go
+++ b/components/node/withdrawals/proof.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/poseidon"
 	"github.com/ethereum/go-ethereum/ethclient/gethclient"
 	"github.com/ethereum/go-ethereum/trie"
-
 	zktrie "github.com/kroma-network/zktrie/trie"
 	zkt "github.com/kroma-network/zktrie/types"
 )


### PR DESCRIPTION
There are some unsorted import statements, so I sorted them using [`goimports-reviser`](https://github.com/incu6us/goimports-reviser).
```bash
> goimports-reviser -rm-unused ./...
```
Currently, `goimports` do not sort import statements consistently (it is well-known issue: https://github.com/golang/go/issues/20818).

There are many other alternatives, and I tried to use `goimports-reviser` since it works well as we desired and they also have linter for sorting import statements (we can add linter to CI in the future as well). 

FYI, you can configure `goimports-reviser` in IntelliJ as described [here](https://github.com/incu6us/goimports-reviser#example-to-configure-it-with-jetbrains-ides-via-file-watcher-plugin).
