### PR TITLE
chore: change git action runner to selfhost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,7 @@ on:
 jobs:
   prepare:
     name: Run CI
-    strategy:
-      matrix:
-        os: [ ubuntu-latest ]
-    runs-on: ${{ matrix.os }}
+    runs-on: self-hosted
 
     outputs:
       kroma-node: ${{ steps.packages.outputs.kroma-node }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,7 @@ on:
 jobs:
   test:
     name: Run tests
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: self-hosted
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
we will maintain `self-hosting` for the time being to improve the issue of failed CI due to limited pipeline performance
