### PR TITLE
ci: change github action runner host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   prepare:
     name: Run CI
-    runs-on: self-hosted
+    runs-on:
+      group: kroma-runners
+      labels: kroma-ubuntu-latest-8core
 
     outputs:
       kroma-node: ${{ steps.packages.outputs.kroma-node }}
@@ -57,7 +59,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-f3c20d5664c8773d4ec3b2b67148cc1032f48f58
 
       - name: Build
         run: yarn build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   test:
     name: Run tests
-    runs-on: self-hosted
+    runs-on:
+      group: kroma-runners
+      labels: kroma-ubuntu-latest-8core
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -47,7 +49,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-f3c20d5664c8773d4ec3b2b67148cc1032f48f58
 
       - name: Build
         run: yarn build


### PR DESCRIPTION
I have been using self-hosting to utilize more computing resources than the default specifications of GitHub Actions when running actions. 
However, I now have the option to use `larger runners`, so I'm switching to that.

> Additionally, we would like to lock/freeze the nightly version.