### PR TITLE
ci: change dev tag name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,9 @@ jobs:
         run: |
           if [[ $GITHUB_REF_TYPE == 'branch' ]];
           then
-            echo ::set-output name=docker-tag::dev
+            echo "docker-tag=dev-$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=docker-tag::${GITHUB_REF#refs/tags/}
+            echo "docker-tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
 
   kroma-node:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-f3c20d5664c8773d4ec3b2b67148cc1032f48f58
+          version: nightly-e15e33a07c0920189fc336391f538c3dad53da73
 
       - name: Build
         run: yarn build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-f3c20d5664c8773d4ec3b2b67148cc1032f48f58
+          version: nightly-e15e33a07c0920189fc336391f538c3dad53da73
 
       - name: Build
         run: yarn build


### PR DESCRIPTION
change the policy to differentiate commits that are merged into the dev branch by tagging them in the docker image

also, the previously used release version is no longer available, so it is being replaced with a compatible alternative version. 