### PR TITLE
fix(validator): close channel and context when Stop() called

### DIFF
--- a/components/validator/challenger.go
+++ b/components/validator/challenger.go
@@ -37,9 +37,6 @@ type Challenger struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	callOpts *bind.CallOpts
-	txOpts   *bind.TransactOpts
-
 	l1Client *ethclient.Client
 
 	l2ooContract      *bindings.L2OutputOracle
@@ -115,8 +112,8 @@ func NewChallenger(ctx context.Context, cfg Config, l log.Logger) (*Challenger, 
 }
 
 // initSub initialize subscriptions
-func (c *Challenger) initSub() {
-	opts := &bind.WatchOpts{Context: c.ctx}
+func (c *Challenger) initSub(ctx context.Context) {
+	opts := &bind.WatchOpts{Context: ctx}
 
 	if !c.cfg.ChallengerDisabled {
 		c.l2OutputSub = event.ResubscribeErr(c.cfg.ResubscribeBackoffMax, func(ctx context.Context, err error) (event.Subscription, error) {
@@ -137,18 +134,16 @@ func (c *Challenger) initSub() {
 
 func (c *Challenger) Start(ctx context.Context, txCandidatesChan chan<- txmgr.TxCandidate) error {
 	c.ctx, c.cancel = context.WithCancel(ctx)
-	c.callOpts = utils.NewCallOptsWithSender(c.ctx, c.cfg.TxManager.From())
-	c.txOpts = utils.NewSimpleTxOpts(c.ctx, c.cfg.TxManager.From(), c.cfg.TxManager.Signer)
 
 	c.log.Info("start challenger")
 
 	c.l2OutputSubmittedEventChan = make(chan *bindings.L2OutputOracleOutputSubmitted)
 	c.challengeCreatedEventChan = make(chan *bindings.ColosseumChallengeCreated)
 	c.txCandidatesChan = txCandidatesChan
-	c.initSub()
+	c.initSub(c.ctx)
 
 	// if checkpoint is behind the latest output index, scan the previous outputs from the checkpoint
-	nextOutputIndex, err := c.l2ooContract.NextOutputIndex(c.callOpts)
+	nextOutputIndex, err := c.l2ooContract.NextOutputIndex(&bind.CallOpts{Context: c.ctx})
 	if err != nil {
 		return fmt.Errorf("failed to get the latest output index: %w", err)
 	}
@@ -160,19 +155,19 @@ func (c *Challenger) Start(ctx context.Context, txCandidatesChan chan<- txmgr.Tx
 		c.checkpoint = new(big.Int).Sub(nextOutputIndex, common.Big1)
 	}
 
-	if err := c.scanPrevOutputs(); err != nil {
+	if err := c.scanPrevOutputs(c.ctx); err != nil {
 		return fmt.Errorf("failed to scan previous outputs: %w", err)
 	}
 
 	// if challenge mode on, subscribe L2 output submission events
 	if !c.cfg.ChallengerDisabled {
 		c.wg.Add(1)
-		go c.subscribeL2OutputSubmitted()
+		go c.subscribeL2OutputSubmitted(c.ctx)
 	}
 
 	// subscribe challenge creation events
 	c.wg.Add(1)
-	go c.subscribeChallengeCreated()
+	go c.subscribeChallengeCreated(c.ctx)
 
 	return nil
 }
@@ -200,8 +195,8 @@ func (c *Challenger) Stop() error {
 // scanPrevOutputs scans all the previous outputs since the checkpoint within the finalization window.
 // If there are invalid outputs, create challenge.
 // If there are challenges in progress, keep handling them.
-func (c *Challenger) scanPrevOutputs() error {
-	status, err := c.cfg.RollupClient.SyncStatus(c.ctx)
+func (c *Challenger) scanPrevOutputs(ctx context.Context) error {
+	status, err := c.cfg.RollupClient.SyncStatus(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get sync status: %w", err)
 	}
@@ -231,7 +226,7 @@ func (c *Challenger) scanPrevOutputs() error {
 		Topics:    [][]common.Hash{topics},
 	}
 
-	logs, err := c.l1Client.FilterLogs(c.ctx, query)
+	logs, err := c.l1Client.FilterLogs(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to get event logs related to outputs: %w", err)
 	}
@@ -243,13 +238,13 @@ func (c *Challenger) scanPrevOutputs() error {
 			ev := NewOutputSubmittedEvent(vLog)
 			// handle output
 			c.wg.Add(1)
-			go c.handleOutput(ev.OutputIndex)
+			go c.handleOutput(ctx, ev.OutputIndex)
 		// for ChallengeCreated event
 		case c.cfg.ColosseumAddr:
 			ev := NewChallengeCreatedEvent(vLog)
 			if ev.OutputIndex.Sign() == 1 && c.isRelatedChallenge(ev.Asserter, ev.Challenger) {
 				c.wg.Add(1)
-				go c.handleChallenge(ev.OutputIndex)
+				go c.handleChallenge(ctx, ev.OutputIndex)
 			}
 		default:
 			c.log.Warn("unknown event log", "logs", vLog)
@@ -262,7 +257,7 @@ func (c *Challenger) scanPrevOutputs() error {
 // subscribeL2OutputSubmitted subscribes the OutputSubmitted event from L2OutputOracle contract.
 // If the L2 output root is invalid, create challenge.
 // This function should be called only when challenger mode is on.
-func (c *Challenger) subscribeL2OutputSubmitted() {
+func (c *Challenger) subscribeL2OutputSubmitted(ctx context.Context) {
 	defer c.wg.Done()
 
 	for {
@@ -272,17 +267,17 @@ func (c *Challenger) subscribeL2OutputSubmitted() {
 			// validate all outputs in between the checkpoint and the current outputIndex
 			for i := c.checkpoint; i.Cmp(ev.L2OutputIndex) != 1; i.Add(i, common.Big1) {
 				c.wg.Add(1)
-				go c.handleOutput(i)
+				go c.handleOutput(ctx, i)
 			}
 			c.checkpoint = ev.L2OutputIndex
-		case <-c.ctx.Done():
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
 // subscribeChallengeCreated subscribes the ChallengeCreated event from Colosseum contract and handle challenge.
-func (c *Challenger) subscribeChallengeCreated() {
+func (c *Challenger) subscribeChallengeCreated(ctx context.Context) {
 	defer c.wg.Done()
 
 	for {
@@ -291,16 +286,16 @@ func (c *Challenger) subscribeChallengeCreated() {
 			// when challenge created, handle it
 			if ev.OutputIndex.Sign() == 1 && c.isRelatedChallenge(ev.Asserter, ev.Challenger) {
 				c.wg.Add(1)
-				go c.handleChallenge(ev.OutputIndex)
+				go c.handleChallenge(ctx, ev.OutputIndex)
 			}
-		case <-c.ctx.Done():
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
 // handleOutput handles output when output submitted
-func (c *Challenger) handleOutput(outputIndex *big.Int) {
+func (c *Challenger) handleOutput(ctx context.Context, outputIndex *big.Int) {
 	defer c.wg.Done()
 
 	ticker := time.NewTicker(time.Minute)
@@ -310,7 +305,7 @@ func (c *Challenger) handleOutput(outputIndex *big.Int) {
 	Loop:
 		select {
 		case <-ticker.C:
-			outputRange, err := c.ValidateOutput(outputIndex)
+			outputRange, err := c.ValidateOutput(ctx, outputIndex)
 			if err != nil {
 				c.log.Error("unable to validate output", "err", err, "outputIndex", outputIndex)
 				break Loop
@@ -323,7 +318,7 @@ func (c *Challenger) handleOutput(outputIndex *big.Int) {
 			}
 
 			// check if the challenge is in progress already.
-			isInProgress, err := c.IsChallengeInProgress(outputIndex)
+			isInProgress, err := c.IsChallengeInProgress(ctx, outputIndex)
 			if err != nil {
 				c.log.Error("unable to get the status of challenge", "err", err, "outputIndex", outputIndex)
 				break Loop
@@ -336,7 +331,7 @@ func (c *Challenger) handleOutput(outputIndex *big.Int) {
 			}
 
 			// if there is no challenge on invalid output, create a new challenge
-			tx, err := c.CreateChallenge(outputRange)
+			tx, err := c.CreateChallenge(ctx, outputRange)
 			if err != nil {
 				c.log.Error("failed to create createChallenge tx", "err", err, "outputIndex", outputIndex)
 				break Loop
@@ -344,14 +339,14 @@ func (c *Challenger) handleOutput(outputIndex *big.Int) {
 
 			c.submitChallengeTx(tx)
 			return
-		case <-c.ctx.Done():
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
 // handleChallenge handles challenge according to its status and role.
-func (c *Challenger) handleChallenge(outputIndex *big.Int) {
+func (c *Challenger) handleChallenge(ctx context.Context, outputIndex *big.Int) {
 	defer c.wg.Done()
 
 	ticker := time.NewTicker(c.cfg.ChallengerPollInterval)
@@ -361,7 +356,7 @@ func (c *Challenger) handleChallenge(outputIndex *big.Int) {
 	Loop:
 		select {
 		case <-ticker.C:
-			challenge, err := c.GetChallenge(outputIndex)
+			challenge, err := c.GetChallenge(ctx, outputIndex)
 			if err != nil {
 				c.log.Error("failed to get challenge", "err", err, "outputIndex", outputIndex)
 				break Loop
@@ -371,7 +366,7 @@ func (c *Challenger) handleChallenge(outputIndex *big.Int) {
 			isChallenger := challenge.Challenger == c.cfg.TxManager.From()
 
 			// check the status of challenge
-			status, err := c.GetChallengeStatus(outputIndex)
+			status, err := c.GetChallengeStatus(ctx, outputIndex)
 			if err != nil {
 				c.log.Error("unable to get challenge status", "err", err, "outputIndex", outputIndex)
 				break Loop
@@ -386,7 +381,7 @@ func (c *Challenger) handleChallenge(outputIndex *big.Int) {
 			// if asserter
 			if isAsserter && !c.cfg.OutputSubmitterDisabled {
 				if status == chal.StatusAsserterTurn {
-					tx, err := c.Bisect(outputIndex)
+					tx, err := c.Bisect(ctx, outputIndex)
 					if err != nil {
 						c.log.Error("asserter: failed to create bisect tx", "err", err, "outputIndex", outputIndex)
 						break Loop
@@ -399,14 +394,14 @@ func (c *Challenger) handleChallenge(outputIndex *big.Int) {
 			if isChallenger && !c.cfg.ChallengerDisabled {
 				switch status {
 				case chal.StatusChallengerTurn:
-					tx, err := c.Bisect(outputIndex)
+					tx, err := c.Bisect(ctx, outputIndex)
 					if err != nil {
 						c.log.Error("challenger: failed to create bisect tx", "err", err, "outputIndex", outputIndex)
 						break Loop
 					}
 					c.submitChallengeTx(tx)
 				case chal.StatusAsserterTimeout, chal.StatusReadyToProve:
-					tx, err := c.ProveFault(outputIndex)
+					tx, err := c.ProveFault(ctx, outputIndex)
 					if err != nil {
 						c.log.Error("failed to create prove fault tx", "err", err, "outputIndex", outputIndex)
 						break Loop
@@ -414,7 +409,7 @@ func (c *Challenger) handleChallenge(outputIndex *big.Int) {
 					c.submitChallengeTx(tx)
 				}
 			}
-		case <-c.ctx.Done():
+		case <-ctx.Done():
 			return
 		}
 	}
@@ -437,16 +432,16 @@ func (c *Challenger) submitChallengeTx(tx *types.Transaction) {
 	}
 }
 
-func (c *Challenger) IsChallengeInProgress(outputIndex *big.Int) (bool, error) {
-	return c.colosseumContract.IsInProgress(c.callOpts, outputIndex)
+func (c *Challenger) IsChallengeInProgress(ctx context.Context, outputIndex *big.Int) (bool, error) {
+	return c.colosseumContract.IsInProgress(&bind.CallOpts{Context: ctx}, outputIndex)
 }
 
-func (c *Challenger) GetChallenge(outputIndex *big.Int) (bindings.TypesChallenge, error) {
-	return c.colosseumContract.GetChallenge(c.callOpts, outputIndex)
+func (c *Challenger) GetChallenge(ctx context.Context, outputIndex *big.Int) (bindings.TypesChallenge, error) {
+	return c.colosseumContract.GetChallenge(&bind.CallOpts{Context: ctx}, outputIndex)
 }
 
-func (c *Challenger) OutputAtBlockSafe(blockNumber uint64, includeNextBlock bool) (*eth.OutputResponse, error) {
-	ctx, cancel := context.WithTimeout(c.ctx, c.cfg.NetworkTimeout)
+func (c *Challenger) OutputAtBlockSafe(ctx context.Context, blockNumber uint64, includeNextBlock bool) (*eth.OutputResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.cfg.NetworkTimeout)
 	defer cancel()
 	output, err := c.cfg.RollupClient.OutputAtBlock(ctx, blockNumber, includeNextBlock)
 	if err != nil {
@@ -461,13 +456,13 @@ type Outputs struct {
 	localOutput  *eth.OutputResponse
 }
 
-func (c *Challenger) outputsAtIndex(outputIndex *big.Int) (*Outputs, error) {
-	remoteOutput, err := c.l2ooContract.GetL2Output(c.callOpts, outputIndex)
+func (c *Challenger) outputsAtIndex(ctx context.Context, outputIndex *big.Int) (*Outputs, error) {
+	remoteOutput, err := c.l2ooContract.GetL2Output(&bind.CallOpts{Context: ctx}, outputIndex)
 	if err != nil {
 		return nil, err
 	}
 
-	localOutput, err := c.OutputAtBlockSafe(remoteOutput.L2BlockNumber.Uint64(), false)
+	localOutput, err := c.OutputAtBlockSafe(ctx, remoteOutput.L2BlockNumber.Uint64(), false)
 	if err != nil {
 		return nil, err
 	}
@@ -482,8 +477,8 @@ type OutputRange struct {
 }
 
 // ValidateOutput validates the output given the outputIndex
-func (c *Challenger) ValidateOutput(outputIndex *big.Int) (*OutputRange, error) {
-	outputs, err := c.outputsAtIndex(outputIndex)
+func (c *Challenger) ValidateOutput(ctx context.Context, outputIndex *big.Int) (*OutputRange, error) {
+	outputs, err := c.outputsAtIndex(ctx, outputIndex)
 	if err != nil {
 		return nil, err
 	}
@@ -519,12 +514,12 @@ func (c *Challenger) isRelatedChallenge(asserter common.Address, challenger comm
 	return c.cfg.TxManager.From() == asserter || c.cfg.TxManager.From() == challenger
 }
 
-func (c *Challenger) GetChallengeStatus(outputIndex *big.Int) (uint8, error) {
-	return c.colosseumContract.GetStatus(c.callOpts, outputIndex)
+func (c *Challenger) GetChallengeStatus(ctx context.Context, outputIndex *big.Int) (uint8, error) {
+	return c.colosseumContract.GetStatus(&bind.CallOpts{Context: ctx}, outputIndex)
 }
 
-func (c *Challenger) BuildSegments(turn uint8, segStart, segSize uint64) (*chal.Segments, error) {
-	sections, err := c.colosseumContract.GetSegmentsLength(c.callOpts, turn)
+func (c *Challenger) BuildSegments(ctx context.Context, turn uint8, segStart, segSize uint64) (*chal.Segments, error) {
+	sections, err := c.colosseumContract.GetSegmentsLength(&bind.CallOpts{Context: ctx}, turn)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get segments length of turn %d: %w", turn, err)
 	}
@@ -532,7 +527,7 @@ func (c *Challenger) BuildSegments(turn uint8, segStart, segSize uint64) (*chal.
 	segments := chal.NewEmptySegments(segStart, segSize, sections.Uint64())
 
 	for i, blockNumber := range segments.BlockNumbers() {
-		output, err := c.OutputAtBlockSafe(blockNumber, false)
+		output, err := c.OutputAtBlockSafe(ctx, blockNumber, false)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get output %d: %w", blockNumber, err)
 		}
@@ -543,9 +538,9 @@ func (c *Challenger) BuildSegments(turn uint8, segStart, segSize uint64) (*chal.
 	return segments, nil
 }
 
-func (c *Challenger) selectFaultPosition(segments *chal.Segments) (*big.Int, error) {
+func (c *Challenger) selectFaultPosition(ctx context.Context, segments *chal.Segments) (*big.Int, error) {
 	for i, blockNumber := range segments.BlockNumbers() {
-		output, err := c.OutputAtBlockSafe(blockNumber, false)
+		output, err := c.OutputAtBlockSafe(ctx, blockNumber, false)
 		if err != nil {
 			return nil, err
 		}
@@ -558,7 +553,7 @@ func (c *Challenger) selectFaultPosition(segments *chal.Segments) (*big.Int, err
 	return nil, errors.New("failed to select fault position")
 }
 
-func (c *Challenger) CreateChallenge(outputRange *OutputRange) (*types.Transaction, error) {
+func (c *Challenger) CreateChallenge(ctx context.Context, outputRange *OutputRange) (*types.Transaction, error) {
 	c.log.Info("crafting createChallenge tx",
 		"index", outputRange.OutputIndex,
 		"start", outputRange.StartBlock,
@@ -566,70 +561,73 @@ func (c *Challenger) CreateChallenge(outputRange *OutputRange) (*types.Transacti
 	)
 
 	segSize := outputRange.EndBlock - outputRange.StartBlock
-	segments, err := c.BuildSegments(1, outputRange.StartBlock, segSize)
+	segments, err := c.BuildSegments(ctx, 1, outputRange.StartBlock, segSize)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.colosseumContract.CreateChallenge(c.txOpts, outputRange.OutputIndex, segments.Hashes)
+	txOpts := utils.NewSimpleTxOpts(ctx, c.cfg.TxManager.From(), c.cfg.TxManager.Signer)
+	return c.colosseumContract.CreateChallenge(txOpts, outputRange.OutputIndex, segments.Hashes)
 }
 
-func (c *Challenger) Bisect(outputIndex *big.Int) (*types.Transaction, error) {
+func (c *Challenger) Bisect(ctx context.Context, outputIndex *big.Int) (*types.Transaction, error) {
 	c.log.Info("crafting bisect tx")
 
-	challenge, err := c.colosseumContract.GetChallenge(c.callOpts, outputIndex)
+	challenge, err := c.colosseumContract.GetChallenge(&bind.CallOpts{Context: ctx}, outputIndex)
 	if err != nil {
 		return nil, err
 	}
 
 	prevSegments := chal.NewSegments(challenge.SegStart.Uint64(), challenge.SegSize.Uint64(), challenge.Segments)
-	position, err := c.selectFaultPosition(prevSegments)
+	position, err := c.selectFaultPosition(ctx, prevSegments)
 	if err != nil {
 		return nil, err
 	}
 	nextTurn := challenge.Turn + 1
 	start, size := prevSegments.NextSegmentsRange(position.Uint64())
-	nextSegments, err := c.BuildSegments(nextTurn, start, size)
+	nextSegments, err := c.BuildSegments(ctx, nextTurn, start, size)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.colosseumContract.Bisect(c.txOpts, outputIndex, position, nextSegments.Hashes)
+	txOpts := utils.NewSimpleTxOpts(ctx, c.cfg.TxManager.From(), c.cfg.TxManager.Signer)
+	return c.colosseumContract.Bisect(txOpts, outputIndex, position, nextSegments.Hashes)
 }
 
-func (c *Challenger) ChallengerTimeout(outputIndex *big.Int) (*types.Transaction, error) {
+func (c *Challenger) ChallengerTimeout(ctx context.Context, outputIndex *big.Int) (*types.Transaction, error) {
 	c.log.Info("crafting timeout tx")
-	return c.colosseumContract.ChallengerTimeout(c.txOpts, outputIndex)
+	txOpts := utils.NewSimpleTxOpts(ctx, c.cfg.TxManager.From(), c.cfg.TxManager.Signer)
+	return c.colosseumContract.ChallengerTimeout(txOpts, outputIndex)
 }
 
 // ProveFault creates proveFault transaction for invalid output root
 // TODO: ProveFault will take long time, so that we may have to handle it carefully
-func (c *Challenger) ProveFault(outputIndex *big.Int) (*types.Transaction, error) {
+func (c *Challenger) ProveFault(ctx context.Context, outputIndex *big.Int) (*types.Transaction, error) {
 	c.log.Info("crafting proveFault tx")
 
-	outputs, err := c.outputsAtIndex(outputIndex)
+	outputs, err := c.outputsAtIndex(ctx, outputIndex)
 	if err != nil {
 		return nil, err
 	}
 
-	challenge, err := c.colosseumContract.GetChallenge(c.callOpts, outputIndex)
+	challenge, err := c.colosseumContract.GetChallenge(&bind.CallOpts{Context: ctx}, outputIndex)
 	if err != nil {
 		return nil, err
 	}
 
 	segments := chal.NewSegments(challenge.SegStart.Uint64(), challenge.SegSize.Uint64(), challenge.Segments)
-	position, err := c.selectFaultPosition(segments)
+	position, err := c.selectFaultPosition(ctx, segments)
 	if err != nil {
 		return nil, err
 	}
 
 	blockNumber := challenge.SegStart.Uint64() + position.Uint64()
-	srcOutput, err := c.OutputAtBlockSafe(blockNumber, true)
+	srcOutput, err := c.OutputAtBlockSafe(ctx, blockNumber, true)
 	if err != nil {
 		return nil, err
 	}
 
-	dstOutput, err := c.OutputAtBlockSafe(blockNumber+1, false)
+	dstOutput, err := c.OutputAtBlockSafe(ctx, blockNumber+1, false)
 	if err != nil {
 		return nil, err
 	}
@@ -652,8 +650,9 @@ func (c *Challenger) ProveFault(outputIndex *big.Int) (*types.Transaction, error
 		return nil, err
 	}
 
+	txOpts := utils.NewSimpleTxOpts(ctx, c.cfg.TxManager.From(), c.cfg.TxManager.Signer)
 	return c.colosseumContract.ProveFault(
-		c.txOpts,
+		txOpts,
 		outputIndex,
 		outputs.localOutput.OutputRoot,
 		position,

--- a/components/validator/guardian.go
+++ b/components/validator/guardian.go
@@ -66,7 +66,7 @@ func (g *Guardian) Start(ctx context.Context, txCandidatesChan chan<- txmgr.TxCa
 
 	g.txCandidatesChan = txCandidatesChan
 	g.wg.Add(1)
-	go g.handleValidationRequested()
+	go g.handleValidationRequested(g.ctx)
 
 	return nil
 }
@@ -86,20 +86,20 @@ func (g *Guardian) Stop() error {
 	return nil
 }
 
-func (g *Guardian) handleValidationRequested() {
+func (g *Guardian) handleValidationRequested(ctx context.Context) {
 	defer g.wg.Done()
 	for {
 		select {
 		case ev := <-g.validationRequestedChan:
 			g.wg.Add(1)
-			go g.processOutputValidation(ev)
-		case <-g.ctx.Done():
+			go g.processOutputValidation(ctx, ev)
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (g *Guardian) processOutputValidation(event *bindings.SecurityCouncilValidationRequested) {
+func (g *Guardian) processOutputValidation(ctx context.Context, event *bindings.SecurityCouncilValidationRequested) {
 	ticker := time.NewTicker(time.Minute)
 	defer func() {
 		ticker.Stop()
@@ -110,7 +110,7 @@ func (g *Guardian) processOutputValidation(event *bindings.SecurityCouncilValida
 	Loop:
 		select {
 		case <-ticker.C:
-			cCtx, cCancel := context.WithTimeout(g.ctx, g.cfg.NetworkTimeout)
+			cCtx, cCancel := context.WithTimeout(ctx, g.cfg.NetworkTimeout)
 			callOpts := utils.NewCallOptsWithSender(cCtx, g.cfg.TxManager.From())
 			isConfirmed, err := g.securityCouncilContract.IsConfirmed(callOpts, event.TransactionId)
 			cCancel()
@@ -124,13 +124,13 @@ func (g *Guardian) processOutputValidation(event *bindings.SecurityCouncilValida
 				return
 			}
 
-			isValid, err := g.validateL2Output(event.OutputRoot, event.L2BlockNumber.Uint64())
+			isValid, err := g.validateL2Output(ctx, event.OutputRoot, event.L2BlockNumber.Uint64())
 			if err != nil {
 				g.log.Error("validateL2Output failed", "err", err, "l2BlockNumber", event.L2BlockNumber.Uint64())
 				break Loop
 			}
 			if isValid {
-				cCtx, cCancel := context.WithTimeout(g.ctx, g.cfg.NetworkTimeout)
+				cCtx, cCancel := context.WithTimeout(ctx, g.cfg.NetworkTimeout)
 				txOpts := utils.NewSimpleTxOpts(cCtx, g.cfg.TxManager.From(), g.cfg.TxManager.Signer)
 				tx, err := g.securityCouncilContract.ConfirmTransaction(txOpts, event.TransactionId)
 				cCancel()
@@ -141,14 +141,14 @@ func (g *Guardian) processOutputValidation(event *bindings.SecurityCouncilValida
 				g.sendTransaction(tx)
 			}
 			return
-		case <-g.ctx.Done():
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (g *Guardian) validateL2Output(outputRoot eth.Bytes32, l2BlockNumber uint64) (bool, error) {
-	localOutputRoot, err := g.outputRootAtBlock(l2BlockNumber)
+func (g *Guardian) validateL2Output(ctx context.Context, outputRoot eth.Bytes32, l2BlockNumber uint64) (bool, error) {
+	localOutputRoot, err := g.outputRootAtBlock(ctx, l2BlockNumber)
 	if err != nil {
 		return false, fmt.Errorf("failed to get outputRootAtBlock: %w", err)
 	}
@@ -156,8 +156,8 @@ func (g *Guardian) validateL2Output(outputRoot eth.Bytes32, l2BlockNumber uint64
 	return isValid, nil
 }
 
-func (g *Guardian) outputRootAtBlock(blockNumber uint64) (eth.Bytes32, error) {
-	cCtx, cCancel := context.WithTimeout(g.ctx, g.cfg.NetworkTimeout)
+func (g *Guardian) outputRootAtBlock(ctx context.Context, blockNumber uint64) (eth.Bytes32, error) {
+	cCtx, cCancel := context.WithTimeout(ctx, g.cfg.NetworkTimeout)
 	defer cCancel()
 	output, err := g.cfg.RollupClient.OutputAtBlock(cCtx, blockNumber, false)
 	if err != nil {

--- a/components/validator/l2_output_submitter.go
+++ b/components/validator/l2_output_submitter.go
@@ -130,7 +130,7 @@ func (l *L2OutputSubmitter) loop() {
 	for {
 		select {
 		case <-l.submitChan:
-			if err := l.trySubmitL2Output(); err != nil {
+			if err := l.trySubmitL2Output(l.ctx); err != nil {
 				l.log.Error("failed to submit l2 output", "err", err)
 				l.retryAfter(l.cfg.OutputSubmitterRetryInterval)
 			}
@@ -150,8 +150,8 @@ func (l *L2OutputSubmitter) retryAfter(d time.Duration) {
 }
 
 // TODO(seolaoh): return wait duration explicitly, and handle `retryAfter` function calls at once.
-func (l *L2OutputSubmitter) trySubmitL2Output() error {
-	nextBlockNumber, canSubmit, err := l.CanSubmit()
+func (l *L2OutputSubmitter) trySubmitL2Output(ctx context.Context) error {
+	nextBlockNumber, canSubmit, err := l.CanSubmit(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to check if it can submit: %w", err)
 	}
@@ -159,7 +159,7 @@ func (l *L2OutputSubmitter) trySubmitL2Output() error {
 		return nil
 	}
 
-	output, err := l.FetchOutput(nextBlockNumber)
+	output, err := l.FetchOutput(ctx, nextBlockNumber)
 	if err != nil {
 		return fmt.Errorf("failed to fetch next output: %w", err)
 	}
@@ -179,8 +179,8 @@ func (l *L2OutputSubmitter) trySubmitL2Output() error {
 }
 
 // CanSubmit checks if submission interval has elapsed and current round conditions.
-func (l *L2OutputSubmitter) CanSubmit() (*big.Int, bool, error) {
-	hasEnoughDeposit, err := l.checkDeposit()
+func (l *L2OutputSubmitter) CanSubmit(ctx context.Context) (*big.Int, bool, error) {
+	hasEnoughDeposit, err := l.checkDeposit(ctx)
 	if err != nil {
 		return nil, false, err
 	}
@@ -189,7 +189,7 @@ func (l *L2OutputSubmitter) CanSubmit() (*big.Int, bool, error) {
 		return nil, false, nil
 	}
 
-	currentBlockNumber, nextBlockNumber, err := l.fetchBlockNumbers()
+	currentBlockNumber, nextBlockNumber, err := l.fetchBlockNumbers(ctx)
 	if err != nil {
 		return nil, false, err
 	}
@@ -211,7 +211,7 @@ func (l *L2OutputSubmitter) CanSubmit() (*big.Int, bool, error) {
 	}
 
 	// Check if it's a public round, or selected for priority validator
-	roundInfo, err := l.fetchCurrentRound()
+	roundInfo, err := l.fetchCurrentRound(ctx)
 	if err != nil {
 		return nil, false, err
 	}
@@ -230,8 +230,8 @@ func (l *L2OutputSubmitter) CanSubmit() (*big.Int, bool, error) {
 	return nextBlockNumber, true, nil
 }
 
-func (l *L2OutputSubmitter) checkDeposit() (bool, error) {
-	cCtx, cCancel := context.WithTimeout(l.ctx, l.cfg.NetworkTimeout)
+func (l *L2OutputSubmitter) checkDeposit(ctx context.Context) (bool, error) {
+	cCtx, cCancel := context.WithTimeout(ctx, l.cfg.NetworkTimeout)
 	defer cCancel()
 	from := l.cfg.TxManager.From()
 	callOpts := utils.NewCallOptsWithSender(cCtx, from)
@@ -249,8 +249,8 @@ func (l *L2OutputSubmitter) checkDeposit() (bool, error) {
 	return true, nil
 }
 
-func (l *L2OutputSubmitter) fetchBlockNumbers() (*big.Int, *big.Int, error) {
-	cCtx, cCancel := context.WithTimeout(l.ctx, l.cfg.NetworkTimeout)
+func (l *L2OutputSubmitter) fetchBlockNumbers(ctx context.Context) (*big.Int, *big.Int, error) {
+	cCtx, cCancel := context.WithTimeout(ctx, l.cfg.NetworkTimeout)
 	callOpts := utils.NewCallOptsWithSender(cCtx, l.cfg.TxManager.From())
 	nextBlockNumber, err := l.l2ooContract.NextBlockNumber(callOpts)
 	if err != nil {
@@ -261,7 +261,7 @@ func (l *L2OutputSubmitter) fetchBlockNumbers() (*big.Int, *big.Int, error) {
 	cCancel()
 
 	// Fetch the current L2 heads
-	cCtx, cCancel = context.WithTimeout(l.ctx, l.cfg.NetworkTimeout)
+	cCtx, cCancel = context.WithTimeout(ctx, l.cfg.NetworkTimeout)
 	defer cCancel()
 	status, err := l.cfg.RollupClient.SyncStatus(cCtx)
 	if err != nil {
@@ -302,8 +302,8 @@ type roundInfo struct {
 
 // fetchCurrentRound fetches next validator address from ValidatorPool contract.
 // It returns if current round is public round, and if selected for priority validator if it's a priority round.
-func (l *L2OutputSubmitter) fetchCurrentRound() (roundInfo, error) {
-	cCtx, cCancel := context.WithTimeout(l.ctx, l.cfg.NetworkTimeout)
+func (l *L2OutputSubmitter) fetchCurrentRound(ctx context.Context) (roundInfo, error) {
+	cCtx, cCancel := context.WithTimeout(ctx, l.cfg.NetworkTimeout)
 	defer cCancel()
 	callOpts := utils.NewCallOptsWithSender(cCtx, l.cfg.TxManager.From())
 	nextValidator, err := l.valpoolContract.NextValidator(callOpts)
@@ -340,8 +340,8 @@ func (l *L2OutputSubmitter) fetchCurrentRound() (roundInfo, error) {
 
 // FetchOutput gets the output information to the corresponding block number.
 // It returns the output info if the output can be made, otherwise error.
-func (l *L2OutputSubmitter) FetchOutput(blockNumber *big.Int) (*eth.OutputResponse, error) {
-	cCtx, cCancel := context.WithTimeout(l.ctx, l.cfg.NetworkTimeout)
+func (l *L2OutputSubmitter) FetchOutput(ctx context.Context, blockNumber *big.Int) (*eth.OutputResponse, error) {
+	cCtx, cCancel := context.WithTimeout(ctx, l.cfg.NetworkTimeout)
 	defer cCancel()
 	output, err := l.cfg.RollupClient.OutputAtBlock(cCtx, blockNumber.Uint64(), false)
 	if err != nil {

--- a/e2e/actions/l2_challenger.go
+++ b/e2e/actions/l2_challenger.go
@@ -11,14 +11,14 @@ import (
 )
 
 func (v *L2Validator) ActCreateChallenge(t Testing, outputIndex *big.Int) common.Hash {
-	isInProgress, err := v.challenger.IsChallengeInProgress(outputIndex)
+	isInProgress, err := v.challenger.IsChallengeInProgress(t.Ctx(), outputIndex)
 	require.NoError(t, err)
 	require.False(t, isInProgress, "another challenge is in progress")
 
-	outputRange, err := v.challenger.ValidateOutput(outputIndex)
+	outputRange, err := v.challenger.ValidateOutput(t.Ctx(), outputIndex)
 	require.NoError(t, err)
 	require.NotNil(t, outputRange)
-	tx, err := v.challenger.CreateChallenge(outputRange)
+	tx, err := v.challenger.CreateChallenge(t.Ctx(), outputRange)
 	require.NoError(t, err, "unable to create createChallenge tx")
 
 	err = v.l1.SendTransaction(t.Ctx(), tx)
@@ -28,7 +28,7 @@ func (v *L2Validator) ActCreateChallenge(t Testing, outputIndex *big.Int) common
 }
 
 func (v *L2Validator) ActBisect(t Testing, outputIndex *big.Int) common.Hash {
-	tx, err := v.challenger.Bisect(outputIndex)
+	tx, err := v.challenger.Bisect(t.Ctx(), outputIndex)
 	require.NoError(t, err, "unable to create bisect tx")
 
 	err = v.l1.SendTransaction(t.Ctx(), tx)
@@ -38,13 +38,13 @@ func (v *L2Validator) ActBisect(t Testing, outputIndex *big.Int) common.Hash {
 }
 
 func (v *L2Validator) ActTimeout(t Testing, outputIndex *big.Int) common.Hash {
-	status, err := v.challenger.GetChallengeStatus(outputIndex)
+	status, err := v.challenger.GetChallengeStatus(t.Ctx(), outputIndex)
 	require.NoError(t, err)
 
 	var tx *types.Transaction
 
 	if status == chal.StatusChallengerTimeout {
-		tx, err = v.challenger.ChallengerTimeout(outputIndex)
+		tx, err = v.challenger.ChallengerTimeout(t.Ctx(), outputIndex)
 		require.NoError(t, err)
 	} else {
 		require.Fail(t, "invalid challenge status")
@@ -59,7 +59,7 @@ func (v *L2Validator) ActTimeout(t Testing, outputIndex *big.Int) common.Hash {
 }
 
 func (v *L2Validator) ActProveFault(t Testing, outputIndex *big.Int) common.Hash {
-	tx, err := v.challenger.ProveFault(outputIndex)
+	tx, err := v.challenger.ProveFault(t.Ctx(), outputIndex)
 	require.NoError(t, err, "unable to create proveFault tx")
 
 	err = v.l1.SendTransaction(t.Ctx(), tx)

--- a/e2e/actions/l2_validator.go
+++ b/e2e/actions/l2_validator.go
@@ -81,10 +81,10 @@ func NewL2Validator(t Testing, log log.Logger, cfg *ValidatorCfg, l1 *ethclient.
 		},
 	}
 
-	l2os, err := validator.NewL2OutputSubmitter(context.Background(), validatorCfg, log, validatormetrics.NoopMetrics, make(chan txmgr.TxCandidate))
+	l2os, err := validator.NewL2OutputSubmitter(context.Background(), validatorCfg, log, validatormetrics.NoopMetrics)
 	require.NoError(t, err)
 
-	challenger, err := validator.NewChallenger(t.Ctx(), validatorCfg, log, make(chan txmgr.TxCandidate))
+	challenger, err := validator.NewChallenger(t.Ctx(), validatorCfg, log)
 	require.NoError(t, err)
 
 	return &L2Validator{
@@ -142,19 +142,19 @@ func (v *L2Validator) sendTx(t Testing, toAddr *common.Address, txValue *big.Int
 }
 
 func (v *L2Validator) CanSubmit(t Testing) bool {
-	_, shouldSubmit, err := v.l2os.CanSubmit()
+	_, shouldSubmit, err := v.l2os.CanSubmit(t.Ctx())
 	require.NoError(t, err)
 	return shouldSubmit
 }
 
 func (v *L2Validator) ActSubmitL2Output(t Testing) {
-	nextBlockNumber, canSubmit, err := v.l2os.CanSubmit()
+	nextBlockNumber, canSubmit, err := v.l2os.CanSubmit(t.Ctx())
 	require.NoError(t, err)
 	if !canSubmit {
 		return
 	}
 
-	output, err := v.l2os.FetchOutput(nextBlockNumber)
+	output, err := v.l2os.FetchOutput(t.Ctx(), nextBlockNumber)
 	require.NoError(t, err)
 
 	txData, err := validator.SubmitL2OutputTxData(v.l2os.L2ooAbi(), output, 1)


### PR DESCRIPTION
Fixed the validator component could not be restarted.
To do this, I modified each function to inject context as a parameter.