### PR TITLE
fix(validator): skip finding fault position in asserter timeout

### DIFF
--- a/e2e/actions/l2_challenger.go
+++ b/e2e/actions/l2_challenger.go
@@ -59,8 +59,8 @@ func (v *L2Validator) ActTimeout(t Testing, outputIndex *big.Int) common.Hash {
 	return tx.Hash()
 }
 
-func (v *L2Validator) ActProveFault(t Testing, outputIndex *big.Int) common.Hash {
-	tx, err := v.challenger.ProveFault(t.Ctx(), outputIndex)
+func (v *L2Validator) ActProveFault(t Testing, outputIndex *big.Int, skipSelectPosition bool) common.Hash {
+	tx, err := v.challenger.ProveFault(t.Ctx(), outputIndex, skipSelectPosition)
 	require.NoError(t, err, "unable to create proveFault tx")
 
 	err = v.l1.SendTransaction(t.Ctx(), tx)

--- a/e2e/actions/l2_challenger_test.go
+++ b/e2e/actions/l2_challenger_test.go
@@ -171,8 +171,11 @@ interaction:
 			// call bisect by validator
 			txHash = validator.ActBisect(t, outputIndex)
 			includeL1Block(t, miner, validator.address)
-		case chal.StatusAsserterTimeout, chal.StatusReadyToProve:
-			txHash = challenger.ActProveFault(t, outputIndex)
+		case chal.StatusAsserterTimeout:
+			txHash = challenger.ActProveFault(t, outputIndex, true)
+			includeL1Block(t, miner, challenger.address)
+		case chal.StatusReadyToProve:
+			txHash = challenger.ActProveFault(t, outputIndex, false)
 			includeL1Block(t, miner, challenger.address)
 		case chal.StatusProven:
 			// validate l2 output submitted by challenger


### PR DESCRIPTION
# Description
When asserter timeout, skip finding fault position since the same segments have been stored in colosseum.
