### PR TITLE
fix(challenger): fetch output with proof when proving fault

### DIFF
--- a/components/validator/challenger.go
+++ b/components/validator/challenger.go
@@ -444,12 +444,12 @@ func (c *Challenger) OutputWithProofAtBlockSafe(ctx context.Context, blockNumber
 }
 
 func (c *Challenger) PublicInputProof(ctx context.Context, blockNumber uint64) (bindings.TypesPublicInputProof, error) {
-	srcOutput, err := c.OutputAtBlockSafe(ctx, blockNumber)
+	srcOutput, err := c.OutputWithProofAtBlockSafe(ctx, blockNumber)
 	if err != nil {
 		return bindings.TypesPublicInputProof{}, err
 	}
 
-	dstOutput, err := c.OutputAtBlockSafe(ctx, blockNumber+1)
+	dstOutput, err := c.OutputWithProofAtBlockSafe(ctx, blockNumber+1)
 	if err != nil {
 		return bindings.TypesPublicInputProof{}, err
 	}


### PR DESCRIPTION
Output with proof is required when proving fault.