### PR TITLE
fix(challenger): change the public input proof of dst output, not src

### DIFF
--- a/components/validator/challenger.go
+++ b/components/validator/challenger.go
@@ -465,7 +465,7 @@ func (c *Challenger) PublicInputProof(ctx context.Context, blockNumber uint64) (
 		return bindings.TypesPublicInputProof{}, err
 	}
 
-	p := srcOutput.PublicInputProof
+	p := dstOutput.PublicInputProof
 
 	var balance [32]byte
 	copy(balance[:], p.L2ToL1MessagePasserBalance.Bytes()[:])


### PR DESCRIPTION
To verify the state of withdrawal account, dst merkle proof is required.
