### PR TITLE
fix(validator): fix several bugs related to challenger

### DIFF
--- a/components/validator/config.go
+++ b/components/validator/config.go
@@ -171,9 +171,12 @@ func NewValidatorConfig(cfg CLIConfig, l log.Logger, m metrics.Metricer) (*Confi
 		return nil, err
 	}
 
-	securityCouncilAddress, err := utils.ParseAddress(cfg.SecurityCouncilAddress)
-	if err != nil {
-		return nil, err
+	var securityCouncilAddress common.Address
+	if cfg.GuardianEnabled {
+		securityCouncilAddress, err = utils.ParseAddress(cfg.SecurityCouncilAddress)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	valPoolAddress, err := utils.ParseAddress(cfg.ValPoolAddress)

--- a/components/validator/guardian.go
+++ b/components/validator/guardian.go
@@ -207,7 +207,7 @@ func (g *Guardian) processOutputValidation(ctx context.Context, event *bindings.
 					break Loop
 				}
 				if tx == nil {
-					log.Error("failed to send confirm tx", "transactionId", event.TransactionId, "err", err)
+					g.log.Error("confirm tx is nil", "transactionId", event.TransactionId, "err", err)
 					return
 				}
 

--- a/packages/contracts/contracts/L1/Colosseum.sol
+++ b/packages/contracts/contracts/L1/Colosseum.sol
@@ -358,7 +358,7 @@ contract Colosseum is Initializable, Semver {
         );
 
         // TODO(pangssu): waiting for the new Verifier.sol to complete.
-        // require(ZK_VERIFIER.verify(_proof, _pair, publicInputHash), "Colosseum: invalid proof");
+        // require(ZK_VERIFIER.verify(_zkproof, _pair, publicInputHash), "Colosseum: invalid proof");
 
         verifiedPublicInputs[publicInputHash] = true;
         challenge.outputRoot = _outputRoot;

--- a/packages/contracts/contracts/libraries/NodeReader.sol
+++ b/packages/contracts/contracts/libraries/NodeReader.sol
@@ -13,7 +13,7 @@ library NodeReader {
      * @custom:value MIDDLE Represents a middle node.
      * @custom:value LEAF   Represents a leaf node.
      * @custom:value EMPTY  Represents a empty node.
-     * @custom:value ROOT   Represents a middle node.
+     * @custom:value ROOT   Represents a root node.
      */
     enum NodeType {
         MIDDLE,


### PR DESCRIPTION
# Description

- Changed to use copy of `*big.Int` type output index when handling output submitted event.
- Changed to fetch proof and pair of destination block number.
- During creating validator config, parse security council address only when guardian is enabled. (if the config is not set, `ParseAddress` throws invalid address error)
- Fixed minor typos
