### PR TITLE
perf(validator): remove delay of output handling

### DIFF
--- a/e2e/actions/l2_challenger_test.go
+++ b/e2e/actions/l2_challenger_test.go
@@ -350,8 +350,10 @@ interaction:
 			// call bisect by validator
 			txHash = validator.ActBisect(t, outputIndex)
 			includeL1Block(t, miner, validator.address)
-		case chal.StatusAsserterTimeout, chal.StatusReadyToProve:
-			txHash = challenger.ActProveFault(t, outputIndex)
+		case chal.StatusAsserterTimeout:
+			// not expected
+		case chal.StatusReadyToProve:
+			txHash = challenger.ActProveFault(t, outputIndex, false)
 			includeL1Block(t, miner, challenger.address)
 		case chal.StatusProven:
 			// validate l2 output submitted by challenger


### PR DESCRIPTION
# Description

When challenger handles each output, it should handle it without any delay. Therefore, changed to listen `ticker.C` in post-condition of for loop.
Also, during challenge handling, the same logic is applied.
