### PR TITLE
perf(validator): handle errors of validator's transactions

### DIFF
--- a/components/validator/config.go
+++ b/components/validator/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	ValidatorPoolAddr            common.Address
 	ChallengerPollInterval       time.Duration
 	NetworkTimeout               time.Duration
-	TxManager                    *txmgr.SimpleTxManager
+	TxManager                    *txmgr.BufferedTxManager
 	L1Client                     *ethclient.Client
 	RollupClient                 *sources.RollupClient
 	RollupConfig                 *rollup.Config
@@ -184,7 +184,7 @@ func NewValidatorConfig(cfg CLIConfig, l log.Logger, m metrics.Metricer) (*Confi
 		return nil, err
 	}
 
-	txManager, err := txmgr.NewSimpleTxManager("validator", l, m, cfg.TxMgrConfig)
+	txManager, err := txmgr.NewBufferedTxManager("validator", l, m, cfg.TxMgrConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/actions/l2_runtime.go
+++ b/e2e/actions/l2_runtime.go
@@ -185,7 +185,11 @@ func (rt *Runtime) setupChallenge() {
 	require.Equal(rt.t, rt.proposer.SyncStatus().UnsafeL2, rt.proposer.SyncStatus().FinalizedL2)
 
 	// create l2 output submission transactions until there is nothing left to submit
-	for rt.validator.CanSubmit(rt.t) {
+	for {
+		waitTime := rt.validator.CalculateWaitTime(rt.t)
+		if waitTime > 0 {
+			break
+		}
 		// and submit it to L1
 		rt.validator.ActSubmitL2Output(rt.t)
 		// include output on L1

--- a/e2e/actions/l2_validator_test.go
+++ b/e2e/actions/l2_validator_test.go
@@ -67,7 +67,11 @@ func TestValidator(gt *testing.T) {
 
 	require.Equal(t, proposer.SyncStatus().UnsafeL2, proposer.SyncStatus().FinalizedL2)
 	// create l2 output submission transactions until there is nothing left to submit
-	for validator.CanSubmit(t) {
+	for {
+		waitTime := validator.CalculateWaitTime(t)
+		if waitTime > 0 {
+			break
+		}
 		// and submit it to L1
 		validator.ActSubmitL2Output(t)
 		// include output on L1

--- a/e2e/actions/user_test.go
+++ b/e2e/actions/user_test.go
@@ -138,7 +138,11 @@ func TestCrossLayerUser(gt *testing.T) {
 	miner.includeL1Block(t, dp.Addresses.TrustedValidator)
 
 	// create l2 output submission transactions until there is nothing left to submit
-	for validator.CanSubmit(t) {
+	for {
+		waitTime := validator.CalculateWaitTime(t)
+		if waitTime > 0 {
+			break
+		}
 		// submit it to L1
 		validator.ActSubmitL2Output(t)
 		// include output on L1

--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"context"
 	"crypto/ecdsa"
-	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -789,13 +788,11 @@ func (cfg SystemConfig) DepositValidatorPool(l1Client *ethclient.Client, priv *e
 	if err != nil {
 		return fmt.Errorf("unable to send deposit transaction: %w", err)
 	}
-	receipt, err := waitForTransaction(tx.Hash(), l1Client, time.Duration(3*cfg.DeployConfig.L1BlockTime)*time.Second)
+	_, err = waitForTransaction(tx.Hash(), l1Client, time.Duration(3*cfg.DeployConfig.L1BlockTime)*time.Second)
 	if err != nil {
 		return fmt.Errorf("unable to wait for validator deposit tx on L1: %w", err)
 	}
-	if receipt.Status != types.ReceiptStatusSuccessful {
-		return errors.New("validator deposit tx failed")
-	}
+
 	return nil
 }
 
@@ -832,9 +829,6 @@ func (cfg SystemConfig) SendTransferTx(l2Prop *ethclient.Client, l2Sync *ethclie
 	receipt, err := waitForL2Transaction(tx.Hash(), l2Sync, 4*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
 	if err != nil {
 		return nil, fmt.Errorf("failed to wait L2 tx on syncer: %w", err)
-	}
-	if receipt.Status != types.ReceiptStatusSuccessful {
-		return nil, errors.New("tx was failed on L2")
 	}
 
 	return receipt, nil

--- a/e2e/system_test.go
+++ b/e2e/system_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"

--- a/e2e/system_test.go
+++ b/e2e/system_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum"
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"

--- a/utils/service/txmgr/buffered_txmgr.go
+++ b/utils/service/txmgr/buffered_txmgr.go
@@ -1,0 +1,125 @@
+package txmgr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/kroma-network/kroma/utils/service/txmgr/metrics"
+)
+
+type BufferedTxManager struct {
+	SimpleTxManager // directly embed
+	wg              sync.WaitGroup
+	txRequestChan   chan *TxRequest
+	ctx             context.Context
+	cancel          context.CancelFunc
+}
+
+type TxRequest struct {
+	ctx          context.Context
+	txCandidate  *TxCandidate
+	responseChan chan *TxResponse
+}
+
+type TxResponse struct {
+	Receipt *types.Receipt
+	Err     error
+}
+
+func NewBufferedTxManager(name string, l log.Logger, m metrics.TxMetricer, cfg CLIConfig) (*BufferedTxManager, error) {
+	simpleTxManager, err := NewSimpleTxManager(name, l, m, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BufferedTxManager{
+		SimpleTxManager: *simpleTxManager,
+	}, nil
+}
+
+func (m *BufferedTxManager) Start(ctx context.Context) error {
+	m.l.Info("starting BufferedTxManager")
+	m.txRequestChan = make(chan *TxRequest, m.Config.TxBufferSize)
+	m.ctx, m.cancel = context.WithCancel(ctx)
+	m.wg.Add(1)
+	go m.listen(m.ctx)
+	return nil
+}
+
+func (m *BufferedTxManager) Stop() error {
+	m.l.Info("stopping BufferedTxManager")
+	m.cancel()
+	m.wg.Wait()
+	close(m.txRequestChan)
+	return nil
+}
+
+func (m *BufferedTxManager) listen(ctx context.Context) {
+	defer m.wg.Done()
+	for {
+		select {
+		case txRequest := <-m.txRequestChan:
+			txReceipt, err := m.Send(txRequest.ctx, *txRequest.txCandidate)
+			if err != nil {
+				m.l.Error("failed to send transaction in buffered tx manager", "err", err)
+			}
+			txRequest.responseChan <- &TxResponse{txReceipt, err}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (m *BufferedTxManager) submitTransaction(ctx context.Context, txCandidate *TxCandidate) *TxResponse {
+	responseChan := make(chan *TxResponse)
+	defer close(responseChan)
+
+	txRequest := &TxRequest{
+		ctx:          ctx,
+		txCandidate:  txCandidate,
+		responseChan: responseChan,
+	}
+	if !m.tryEnqueue(txRequest) {
+		return &TxResponse{
+			nil, errors.New("submit transaction failed in tryEnqueue"),
+		}
+	}
+	return txRequest.waitForResponse()
+}
+
+func (m *BufferedTxManager) SendTxCandidate(ctx context.Context, txCandidate *TxCandidate) *TxResponse {
+	return m.submitTransaction(ctx, txCandidate)
+}
+
+func (m *BufferedTxManager) SendTransaction(ctx context.Context, tx *types.Transaction) *TxResponse {
+	return m.SendTxCandidate(ctx, &TxCandidate{
+		TxData:   tx.Data(),
+		To:       tx.To(),
+		GasLimit: 0,
+	})
+}
+
+func (m *BufferedTxManager) tryEnqueue(txRequest *TxRequest) bool {
+	select {
+	case m.txRequestChan <- txRequest:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *TxRequest) waitForResponse() *TxResponse {
+	for {
+		select {
+		case response := <-r.responseChan:
+			return response
+		case <-r.ctx.Done():
+			return &TxResponse{Err: fmt.Errorf("context cancelled in WaitForResponse: %w", r.ctx.Err())}
+		}
+	}
+}

--- a/utils/service/txmgr/txmgr.go
+++ b/utils/service/txmgr/txmgr.go
@@ -261,6 +261,7 @@ func (m *SimpleTxManager) send(ctx context.Context, tx *types.Transaction) (*typ
 			if receipt.Status != types.ReceiptStatusSuccessful {
 				return receipt, ErrTxReceiptNotSucceed
 			}
+			m.l.Info("Transaction receipt status successful", "hash", receipt.TxHash)
 			return receipt, nil
 		}
 	}


### PR DESCRIPTION
# Description

Fixes the current way of not receiving a response to a transaction request. 
Improved the way we can check for receipt in a synchronous manner, rather than simply passing a transaction request and being done with it in an asynchronous manner.
And use this to efficiently improve the retry logic based on the validators' responses.

Fixes #93