### PR TITLE
fix(node): fix the engine sync api getting stuck

### DIFF
--- a/components/node/rollup/driver/state.go
+++ b/components/node/rollup/driver/state.go
@@ -446,15 +446,14 @@ func (d *Driver) BlockRefsWithStatus(ctx context.Context, num uint64) (eth.L2Blo
 	wait := make(chan struct{})
 	select {
 	case d.stateReq <- wait:
+		nextRef := eth.L2BlockRef{}
+
 		resp := d.syncStatus()
 		ref, err := d.l2.L2BlockRefByNumber(ctx, num)
-		if err != nil {
-			return eth.L2BlockRef{}, eth.L2BlockRef{}, nil, err
+		if err == nil {
+			nextRef, err = d.l2.L2BlockRefByNumber(ctx, num+1)
 		}
-		nextRef, err := d.l2.L2BlockRefByNumber(ctx, num+1)
-		if err != nil {
-			return eth.L2BlockRef{}, eth.L2BlockRef{}, nil, err
-		}
+
 		<-wait
 		return ref, nextRef, resp, err
 	case <-ctx.Done():


### PR DESCRIPTION
# Description
The issue where subsequent engine sync API functionalities do not work if an error occurs during the execution of the `BlockRefsWithStatus` function has been fixed.

## Issue
If an error occurs during the execution of the `BlockRefsWithStatus` function in the node's state driver (for example, when trying to query a non-existing block), all subsequent functions of the state driver do not work.
As a result, the node cannot proceed with the derivation, and therefore the geth will not be able to keep up with the latest block.

## Changes
Modified the `BlockRefsWithStatus` function in the state driver to always send a signal to the wait channel (`<- wait`) even when an error occurs.