### PR TITLE
fix(validator): prevent validator unnecessary waiting

### DIFF
--- a/components/validator/guardian.go
+++ b/components/validator/guardian.go
@@ -177,7 +177,7 @@ func (g *Guardian) processOutputValidation(ctx context.Context, event *bindings.
 		select {
 		case <-ticker.C:
 			cCtx, cCancel := context.WithTimeout(ctx, g.cfg.NetworkTimeout)
-			callOpts := utils.NewCallOptsWithSender(cCtx, g.cfg.TxManager.From())
+			callOpts := utils.NewSimpleCallOpts(cCtx)
 			isConfirmed, err := g.securityCouncilContract.IsConfirmed(callOpts, event.TransactionId)
 			cCancel()
 			if err != nil {


### PR DESCRIPTION
# Description

When first turned on the validator node when the chain is already far along, the validator needs to sync all the L2 blocks before it can attempt to submit output. 
Therefore, changed to polling until sync is completed instead of waiting L2 block time for each block.
