### PR TITLE
ci: remove checkout submodules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: true
-          token: ${{ secrets.KROMA_GITHUB_TOKEN }}
 
       - name: Setup Go 1.19
         uses: actions/setup-go@v4
@@ -88,8 +86,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: true
-          token: ${{ secrets.KROMA_GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -119,8 +115,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: true
-          token: ${{ secrets.KROMA_GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -150,8 +144,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: true
-          token: ${{ secrets.KROMA_GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: true
-          token: ${{ secrets.KROMA_GITHUB_TOKEN }}
 
       - name: Setup Go 1.19
         uses: actions/setup-go@v4


### PR DESCRIPTION
We aren't using submodules in this project.
We believe that using tokens to get submodules in CI is now unnecessary.