### PR TITLE
fix: fix vulnerabilities reported to ZKTRIE

### DIFF
--- a/packages/contracts/contracts/L1/ZKMerkleTrie.sol
+++ b/packages/contracts/contracts/L1/ZKMerkleTrie.sol
@@ -99,7 +99,10 @@ contract ZKMerkleTrie is IZKMerkleTrie, ZKTrieHasher {
                 );
             } else if (currentNode.nodeType == NodeReader.NodeType.LEAF) {
                 require(!exists && !empty, "ZKMerkleTrie: duplicated terminal node");
-                exists = true;
+                exists = currentNode.nodeKey == key;
+                if (!exists) {
+                    break;
+                }
                 computedKey = _hashFixed3Elems(
                     bytes32(uint256(1)),
                     currentNode.nodeKey,

--- a/packages/contracts/contracts/L1/ZKMerkleTrie.sol
+++ b/packages/contracts/contracts/L1/ZKMerkleTrie.sol
@@ -98,7 +98,7 @@ contract ZKMerkleTrie is IZKMerkleTrie, ZKTrieHasher {
                     currentNode.childR
                 );
             } else if (currentNode.nodeType == NodeReader.NodeType.LEAF) {
-                require(!exists, "ZKMerkleTrie: duplicated leaf node");
+                require(!exists && !empty, "ZKMerkleTrie: duplicated terminal node");
                 exists = true;
                 computedKey = _hashFixed3Elems(
                     bytes32(uint256(1)),
@@ -121,7 +121,7 @@ contract ZKMerkleTrie is IZKMerkleTrie, ZKTrieHasher {
                     );
                 }
             } else if (currentNode.nodeType == NodeReader.NodeType.EMPTY) {
-                require(!empty, "ZKMerkleTrie: duplicated empty node");
+                require(!exists && !empty, "ZKMerkleTrie: duplicated terminal node");
                 empty = true;
             }
             if (i == 0) {


### PR DESCRIPTION
# Description

This commit resolves two audit issues.
https://github.com/chainlight-io/2023-kroma-network-audit-issues-client/issues/5
https://github.com/chainlight-io/2023-kroma-network-audit-issues-client/issues/6

Issue KROMA-005 is clearly a critical issue on its face.
However, the vulnerability cannot be exploited because of the following piece of code below.

```solidity
if (currentNode.keyPreimage != bytes32(0)) {
    // NOTE(chokobole): The comparison order is important, because in this setting,
    // first condition is mostly evaluted to be true. When we're sure about
    // database preimage, then we need to enable just one of check below!
    require(
        currentNode.keyPreimage == _key || currentNode.keyPreimage == key,
        "ZKMerkleTrie: invalid key preimage"
    );
}
```

Note that we're only checking if currentNode.keyPreimage exists, but @chokobole told me it always exists, so it's not a vulnerability as a result.
However, it's definitely a problem in the source code, and it's likely to be a problem in the future, so we're fixing it.