### PR TITLE
fix: validate compressedFlags

### DIFF
--- a/packages/contracts/contracts/libraries/NodeReader.sol
+++ b/packages/contracts/contracts/libraries/NodeReader.sol
@@ -173,6 +173,7 @@ library NodeReader {
             // TODO(chokobole): Do the length check as much as possible at once and read the bytes.
             node.nodeKey = readBytes32(item);
             (uint32 compressedFlags, uint256 valuePreimageLen) = readCompressedFlags(item);
+            require((compressedFlags == 1 && valuePreimageLen == 1) || (compressedFlags == 4 && valuePreimageLen == 4), "NodeReader: invalid compressedFlags");
             node.compressedFlags = compressedFlags;
             node.valuePreimage = new bytes32[](valuePreimageLen);
             for (uint256 i = 0; i < valuePreimageLen; ) {


### PR DESCRIPTION
# Description

Related https://github.com/chainlight-io/2023-kroma-network-audit-issues-client/issues/8

Depending on the number of parameters in _compressedFlags and _values, _valueHash may not hash even once. 
ex
```solidity
bytes32 valueHash = _valueHash(0, "hello world!")
// valueHash does not hashed. it is "hello world!"
```

Initially, we were going to verify that _compressedFlags is non-zero in _valueHash, but since it's a low-level function, it could be used for anything, so we decided to verify it when creating the leaf node.