### PR TITLE
chore: improve usage of Context.WithTimeout

### DIFF
--- a/components/batcher/batch_submitter.go
+++ b/components/batcher/batch_submitter.go
@@ -67,8 +67,8 @@ func (b *BatchSubmitter) LoadBlocksIntoState(ctx context.Context) {
 // loadBlockIntoState fetches & stores a single block into `state`. It returns the block it loaded.
 func (b *BatchSubmitter) loadBlockIntoState(ctx context.Context, blockNumber uint64) (eth.BlockID, error) {
 	ctx, cancel := context.WithTimeout(ctx, b.NetworkTimeout)
+	defer cancel()
 	block, err := b.L2Client.BlockByNumber(ctx, new(big.Int).SetUint64(blockNumber))
-	cancel()
 	if err != nil {
 		return eth.BlockID{}, err
 	}

--- a/components/node/p2p/discovery.go
+++ b/components/node/p2p/discovery.go
@@ -275,14 +275,16 @@ func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, cfg *rol
 			if !ok {
 				return
 			}
-			addrs := n.Host().Peerstore().Addrs(id)
-			log.Info("attempting connection", "peer", id)
-			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-			err := n.Host().Connect(ctx, peer.AddrInfo{ID: id, Addrs: addrs})
-			cancel()
-			if err != nil {
-				log.Debug("failed connection attempt", "peer", id, "err", err)
-			}
+			func() {
+				addrs := n.Host().Peerstore().Addrs(id)
+				log.Info("attempting connection", "peer", id)
+				ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+				defer cancel()
+				err := n.Host().Connect(ctx, peer.AddrInfo{ID: id, Addrs: addrs})
+				if err != nil {
+					log.Debug("failed connection attempt", "peer", id, "err", err)
+				}
+			}()
 		}
 	}
 

--- a/components/node/rollup/driver/state.go
+++ b/components/node/rollup/driver/state.go
@@ -257,13 +257,15 @@ func (d *Driver) eventLoop() {
 			}
 			planProposerAction() // schedule the next proposer action to keep the proposing looping
 		case <-altSyncTicker.C:
-			// Check if there is a gap in the current unsafe payload queue.
-			ctx, cancel := context.WithTimeout(ctx, time.Second*2)
-			err := d.checkForGapInUnsafeQueue(ctx)
-			cancel()
-			if err != nil {
-				d.log.Warn("failed to check for unsafe L2 blocks to sync", "err", err)
-			}
+			func() {
+				// Check if there is a gap in the current unsafe payload queue.
+				ctx, cancel := context.WithTimeout(ctx, time.Second*2)
+				defer cancel()
+				err := d.checkForGapInUnsafeQueue(ctx)
+				if err != nil {
+					d.log.Warn("failed to check for unsafe L2 blocks to sync", "err", err)
+				}
+			}()
 		case payload := <-d.unsafeL2Payloads:
 			d.snapshot("New unsafe payload")
 			d.log.Info("Optimistically queueing unsafe L2 execution payload", "id", payload.ID())

--- a/components/validator/guardian.go
+++ b/components/validator/guardian.go
@@ -176,8 +176,8 @@ func (g *Guardian) checkConfirmCondition(transactionId *big.Int, l2BlockNumber *
 	}
 
 	cCtx, cCancel := context.WithTimeout(g.ctx, g.cfg.NetworkTimeout)
+	defer cCancel()
 	executionTx, err := g.securityCouncilContract.Transactions(utils.NewSimpleCallOpts(cCtx), transactionId)
-	cCancel()
 	if err != nil {
 		return true, fmt.Errorf("failed to get transaction with transactionId %d: %w", transactionId.Int64(), err)
 	}

--- a/components/validator/l2_output_submitter.go
+++ b/components/validator/l2_output_submitter.go
@@ -69,12 +69,11 @@ func NewL2OutputSubmitter(ctx context.Context, cfg Config, l log.Logger, m metri
 	}
 
 	cCtx, cCancel := context.WithTimeout(ctx, cfg.NetworkTimeout)
+	defer cCancel()
 	l2BlockTime, err := l2ooContract.L2BLOCKTIME(utils.NewSimpleCallOpts(cCtx))
 	if err != nil {
-		cCancel()
 		return nil, fmt.Errorf("failed to get l2 block time: %w", err)
 	}
-	cCancel()
 
 	cCtx, cCancel = context.WithTimeout(ctx, cfg.NetworkTimeout)
 	defer cCancel()


### PR DESCRIPTION
# Description

Related [[KROMA-012] Incorrect usage of Context.WithTimeout may lead to resource leak](https://github.com/chainlight-io/2023-kroma-network-audit-issues-client/issues/12) reported by theori audit.

At this point, i don't see this as an issue in terms of code behavior, but automated management of context via defer is a pattern that avoids potential issues, so i've implemented it.
