### PR TITLE
fix(node): fix typo in JSON Tag

### DIFF
--- a/components/node/rollup/derive/frame.go
+++ b/components/node/rollup/derive/frame.go
@@ -27,7 +27,7 @@ type Frame struct {
 	ID          ChannelID `json:"id"`
 	FrameNumber uint16    `json:"frame_number"`
 	Data        []byte    `json:"data"`
-	IsLast      bool      `'json:"is_last"`
+	IsLast      bool      `json:"is_last"`
 }
 
 // MarshalBinary writes the frame to `w`.


### PR DESCRIPTION
# Description

Related [[KROMA-013] Typo in JSON Tag of Marshal Frame struct definition](https://github.com/chainlight-io/2023-kroma-network-audit-issues-client/issues/13) reported by theori audit.

Fix typo in the JSON Tag of a struct definition.
