### PR TITLE
chore(contracts): remove safely modified comment in `L2OutputOracle`

### DIFF
--- a/packages/contracts/contracts/L1/L2OutputOracle.sol
+++ b/packages/contracts/contracts/L1/L2OutputOracle.sol
@@ -28,7 +28,8 @@ contract L2OutputOracle is Initializable, Semver {
 
     /**
      * @notice The interval in L2 blocks at which checkpoints must be submitted. Although this is
-     *         immutable, it can safely be modified by upgrading the implementation contract.
+     *         immutable, it can be modified by upgrading the implementation contract.
+     *         Note that nodes that fetch and use this value need to restart when it is modified.
      */
     uint256 public immutable SUBMISSION_INTERVAL;
 


### PR DESCRIPTION
Related to [[KROMA-010] Nodes should be able to handle configuration changes of contracts](https://github.com/chainlight-io/2023-kroma-network-audit-issues-client/issues/10) reported by theori audit.

**NOTE:** need to update client code in near future to reflect changed `immutable` variables when changed.