### PR TITLE
fix(validator): skip request deletion when output already been deleted

### DIFF
--- a/components/validator/guardian.go
+++ b/components/validator/guardian.go
@@ -533,6 +533,11 @@ func (g *Guardian) shouldBeDeleted(outputIndex, fromBlock, toBlock *big.Int) (bo
 		return false, fmt.Errorf("failed to get output from L2OutputOracle contract(outputIndex: %d): %w", outputIndex.Uint64(), err)
 	}
 
+	if IsOutputDeleted(output.OutputRoot) {
+		g.log.Info("output has already been deleted", "outputIndex", outputIndex)
+		return false, nil
+	}
+
 	isValid, err := g.ValidateL2Output(g.ctx, output.OutputRoot, output.L2BlockNumber.Uint64())
 	if err != nil {
 		return false, err


### PR DESCRIPTION
# Description

If an output has already been deleted, there is no need to make a request to delete the output.
Let guardian skip the deleted output.
