### PR TITLE
chore: bump npm packages to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kroma",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "author": "Lightscale Inc.",
   "license": "MIT",
   "workspaces": {

--- a/packages/common-ts/package.json
+++ b/packages/common-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kroma-network/common-ts",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "[Kroma] Advanced typescript tooling used by various services",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kroma-network/contracts",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Contracts for Kroma",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kroma-network/core-utils",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "[Kroma] Core typescript utilities",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/hardhat-deploy-config/package.json
+++ b/packages/hardhat-deploy-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kroma-network/hardhat-deploy-config",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "[Kroma] Hardhat deploy configuration plugin",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kroma-network/sdk",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "[Kroma] Tools for working with Kroma",
   "main": "dist/index",
   "types": "dist/index",


### PR DESCRIPTION
# Description

bump up npm packages to v1.0.0

See

- https://www.npmjs.com/package/@kroma-network/hardhat-deploy-config
- https://www.npmjs.com/package/@kroma-network/common-ts
- https://www.npmjs.com/package/@kroma-network/core-utils
- https://www.npmjs.com/package/@kroma-network/sdk
- https://www.npmjs.com/package/@kroma-network/contracts