### PR TITLE
feat(node): implement engine P2P sync mode

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -10,6 +10,10 @@
 
 - <https://github.com/ethereum-optimism/optimism/commit/af736c12e36e93fb30efdccd8d663f445b0bc7a8>
 
+### Engine P2P Sync
+
+- <https://github.com/ethereum-optimism/optimism/pull/6243>
+
 ### Others
 
 - <https://github.com/ethereum-optimism/optimism/pull/5106>

--- a/components/node/eth/sync_status.go
+++ b/components/node/eth/sync_status.go
@@ -35,4 +35,7 @@ type SyncStatus struct {
 	// UnsafeL2SyncTarget points to the first unprocessed unsafe L2 block.
 	// It may be zeroed if there is no targeted block.
 	UnsafeL2SyncTarget L2BlockRef `json:"queued_unsafe_l2"`
+	// EngineSyncTarget points to the L2 block that the execution engine is syncing to.
+	// If it is ahead from UnsafeL2, the engine is in progress of P2P sync.
+	EngineSyncTarget L2BlockRef `json:"engine_sync_target"`
 }

--- a/components/node/flags/flags.go
+++ b/components/node/flags/flags.go
@@ -209,6 +209,19 @@ var (
 		EnvVars:  prefixEnvVar("L2_BACKUP_UNSAFE_SYNC_RPC_TRUST_RPC"),
 		Required: false,
 	}
+	L2EngineSyncEnabled = &cli.BoolFlag{
+		Name:     "l2.engine-sync",
+		Usage:    "Enables or disables execution engine P2P sync",
+		EnvVars:  prefixEnvVar("L2_ENGINE_SYNC_ENABLED"),
+		Required: false,
+	}
+	SkipSyncStartCheck = &cli.BoolFlag{
+		Name: "l2.skip-sync-start-check",
+		Usage: "Skip sanity check of consistency of L1 origins of the unsafe L2 blocks when determining the sync-starting point. " +
+			"This defers the L1-origin verification, and is recommended to use in when utilizing l2.engine-sync",
+		EnvVars:  prefixEnvVar("L2_SKIP_SYNC_START_CHECK"),
+		Required: false,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -246,6 +259,8 @@ var optionalFlags = []cli.Flag{
 	HeartbeatURLFlag,
 	BackupL2UnsafeSyncRPC,
 	BackupL2UnsafeSyncRPCTrustRPC,
+	L2EngineSyncEnabled,
+	SkipSyncStartCheck,
 }
 
 // Flags contains the list of configuration options available to the binary.

--- a/components/node/node/config.go
+++ b/components/node/node/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kroma-network/kroma/components/node/p2p"
 	"github.com/kroma-network/kroma/components/node/rollup"
 	"github.com/kroma-network/kroma/components/node/rollup/driver"
+	"github.com/kroma-network/kroma/components/node/rollup/sync"
 	kpprof "github.com/kroma-network/kroma/utils/service/pprof"
 )
 
@@ -39,6 +40,8 @@ type Config struct {
 	// Optional
 	Tracer    Tracer
 	Heartbeat HeartbeatConfig
+
+	Sync sync.Config
 }
 
 type RPCConfig struct {

--- a/components/node/node/node.go
+++ b/components/node/node/node.go
@@ -198,7 +198,7 @@ func (n *KromaNode) initL2(ctx context.Context, cfg *Config, snapshotLog log.Log
 		return err
 	}
 
-	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n, n, n.log, snapshotLog, n.metrics)
+	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n, n, n.log, snapshotLog, n.metrics, &cfg.Sync)
 
 	return nil
 }

--- a/components/node/node/server_test.go
+++ b/components/node/node/server_test.go
@@ -187,6 +187,7 @@ func randomSyncStatus(rng *rand.Rand) *eth.SyncStatus {
 		SafeL2:             testutils.RandomL2BlockRef(rng),
 		FinalizedL2:        testutils.RandomL2BlockRef(rng),
 		UnsafeL2SyncTarget: testutils.RandomL2BlockRef(rng),
+		EngineSyncTarget:   testutils.RandomL2BlockRef(rng),
 	}
 }
 

--- a/components/node/rollup/derive/batch_queue.go
+++ b/components/node/rollup/derive/batch_queue.go
@@ -98,7 +98,7 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) 
 		if outOfData {
 			return nil, io.EOF
 		} else {
-			return nil, NotEnoughData
+			return nil, ErrNotEnoughData
 		}
 	}
 
@@ -107,7 +107,7 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) 
 	if err == io.EOF && outOfData {
 		return nil, io.EOF
 	} else if err == io.EOF {
-		return nil, NotEnoughData
+		return nil, ErrNotEnoughData
 	} else if err != nil {
 		return nil, err
 	}

--- a/components/node/rollup/derive/batch_queue_test.go
+++ b/components/node/rollup/derive/batch_queue_test.go
@@ -312,7 +312,7 @@ func TestBatchQueueMissing(t *testing.T) {
 
 	for i := 0; i < len(batches); i++ {
 		b, e := bq.NextBatch(context.Background(), safeHead)
-		require.ErrorIs(t, e, NotEnoughData)
+		require.ErrorIs(t, e, ErrNotEnoughData)
 		require.Nil(t, b)
 	}
 

--- a/components/node/rollup/derive/channel_bank.go
+++ b/components/node/rollup/derive/channel_bank.go
@@ -157,7 +157,7 @@ func (cb *ChannelBank) NextData(ctx context.Context) ([]byte, error) {
 		return nil, err
 	} else {
 		cb.IngestFrame(frame)
-		return nil, NotEnoughData
+		return nil, ErrNotEnoughData
 	}
 }
 

--- a/components/node/rollup/derive/channel_bank_test.go
+++ b/components/node/rollup/derive/channel_bank_test.go
@@ -106,17 +106,17 @@ func TestChannelBankSimple(t *testing.T) {
 
 	// Load the first frame
 	out, err := cb.NextData(context.Background())
-	require.ErrorIs(t, err, NotEnoughData)
+	require.ErrorIs(t, err, ErrNotEnoughData)
 	require.Equal(t, []byte(nil), out)
 
 	// Load the third frame
 	out, err = cb.NextData(context.Background())
-	require.ErrorIs(t, err, NotEnoughData)
+	require.ErrorIs(t, err, ErrNotEnoughData)
 	require.Equal(t, []byte(nil), out)
 
 	// Load the second frame
 	out, err = cb.NextData(context.Background())
-	require.ErrorIs(t, err, NotEnoughData)
+	require.ErrorIs(t, err, ErrNotEnoughData)
 	require.Equal(t, []byte(nil), out)
 
 	// Pull out the channel data
@@ -146,25 +146,25 @@ func TestChannelBankDuplicates(t *testing.T) {
 
 	// Load the first frame
 	out, err := cb.NextData(context.Background())
-	require.ErrorIs(t, err, NotEnoughData)
+	require.ErrorIs(t, err, ErrNotEnoughData)
 	require.Equal(t, []byte(nil), out)
 
 	// Load the third frame
 	out, err = cb.NextData(context.Background())
-	require.ErrorIs(t, err, NotEnoughData)
+	require.ErrorIs(t, err, ErrNotEnoughData)
 	require.Equal(t, []byte(nil), out)
 
 	// Load the duplicate frames
 	out, err = cb.NextData(context.Background())
-	require.ErrorIs(t, err, NotEnoughData)
+	require.ErrorIs(t, err, ErrNotEnoughData)
 	require.Equal(t, []byte(nil), out)
 	out, err = cb.NextData(context.Background())
-	require.ErrorIs(t, err, NotEnoughData)
+	require.ErrorIs(t, err, ErrNotEnoughData)
 	require.Equal(t, []byte(nil), out)
 
 	// Load the second frame
 	out, err = cb.NextData(context.Background())
-	require.ErrorIs(t, err, NotEnoughData)
+	require.ErrorIs(t, err, ErrNotEnoughData)
 	require.Equal(t, []byte(nil), out)
 
 	// Pull out the channel data. Expect to see the original set & not the duplicates

--- a/components/node/rollup/derive/channel_in_reader.go
+++ b/components/node/rollup/derive/channel_in_reader.go
@@ -78,11 +78,11 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (*BatchData, error) {
 	batch, err := cr.nextBatchFn()
 	if err == io.EOF {
 		cr.NextChannel()
-		return nil, NotEnoughData
+		return nil, ErrNotEnoughData
 	} else if err != nil {
 		cr.log.Warn("failed to read batch from channel reader, skipping to next channel now", "err", err)
 		cr.NextChannel()
-		return nil, NotEnoughData
+		return nil, ErrNotEnoughData
 	}
 	return batch.Batch, nil
 }

--- a/components/node/rollup/derive/engine_queue.go
+++ b/components/node/rollup/derive/engine_queue.go
@@ -102,6 +102,10 @@ type EngineQueue struct {
 	safeHead   eth.L2BlockRef
 	unsafeHead eth.L2BlockRef
 
+	// Target L2 block the engine is currently syncing to.
+	// If the engine p2p sync is enabled, it can be different with unsafeHead. Otherwise, it must be same with unsafeHead.
+	engineSyncTarget eth.L2BlockRef
+
 	buildingOnto eth.L2BlockRef
 	buildingID   eth.PayloadID
 	buildingSafe bool
@@ -133,12 +137,14 @@ type EngineQueue struct {
 
 	metrics   Metrics
 	l1Fetcher L1Fetcher
+
+	syncCfg *sync.Config
 }
 
 var _ EngineControl = (*EngineQueue)(nil)
 
 // NewEngineQueue creates a new EngineQueue, which should be Reset(origin) before use.
-func NewEngineQueue(log log.Logger, cfg *rollup.Config, engine Engine, metrics Metrics, prev NextAttributesProvider, l1Fetcher L1Fetcher) *EngineQueue {
+func NewEngineQueue(log log.Logger, cfg *rollup.Config, engine Engine, metrics Metrics, prev NextAttributesProvider, l1Fetcher L1Fetcher, syncCfg *sync.Config) *EngineQueue {
 	return &EngineQueue{
 		log:            log,
 		cfg:            cfg,
@@ -148,6 +154,7 @@ func NewEngineQueue(log log.Logger, cfg *rollup.Config, engine Engine, metrics M
 		unsafePayloads: NewPayloadsQueue(maxUnsafePayloadsMemory, payloadMemSize),
 		prev:           prev,
 		l1Fetcher:      l1Fetcher,
+		syncCfg:        syncCfg,
 	}
 }
 
@@ -163,6 +170,11 @@ func (eq *EngineQueue) SystemConfig() eth.SystemConfig {
 func (eq *EngineQueue) SetUnsafeHead(head eth.L2BlockRef) {
 	eq.unsafeHead = head
 	eq.metrics.RecordL2Ref("l2_unsafe", head)
+}
+
+func (eq *EngineQueue) SetEngineSyncTarget(head eth.L2BlockRef) {
+	eq.engineSyncTarget = head
+	eq.metrics.RecordL2Ref("l2_engineSyncTarget", head)
 }
 
 func (eq *EngineQueue) AddUnsafePayload(payload *eth.ExecutionPayload) {
@@ -221,9 +233,30 @@ func (eq *EngineQueue) SafeL2Head() eth.L2BlockRef {
 	return eq.safeHead
 }
 
+func (eq *EngineQueue) EngineSyncTarget() eth.L2BlockRef {
+	return eq.engineSyncTarget
+}
+
+// Determine if the engine is syncing to the target block
+func (eq *EngineQueue) isEngineSyncing() bool {
+	return eq.unsafeHead.Hash != eq.engineSyncTarget.Hash
+}
+
 func (eq *EngineQueue) Step(ctx context.Context) error {
 	if eq.needForkchoiceUpdate {
 		return eq.tryUpdateEngine(ctx)
+	}
+	// Trying unsafe payload should be done before safe attributes
+	// It allows the unsafe head can move forward while the long-range consolidation is in progress.
+	if eq.unsafePayloads.Len() > 0 {
+		if err := eq.tryNextUnsafePayload(ctx); err != io.EOF {
+			return err
+		}
+		// EOF error means we can't process the next unsafe payload. Then we should process next safe attributes.
+	}
+	if eq.isEngineSyncing() {
+		// Make pipeline first focus to sync unsafe blocks to engineSyncTarget
+		return ErrEngineP2PSyncing
 	}
 	if eq.safeAttributes != nil {
 		return eq.tryNextSafeAttributes(ctx)
@@ -250,11 +283,7 @@ func (eq *EngineQueue) Step(ctx context.Context) error {
 			parent:     eq.safeHead,
 		}
 		eq.log.Debug("Adding next safe attributes", "safe_head", eq.safeHead, "next", next)
-		return NotEnoughData
-	}
-
-	if eq.unsafePayloads.Len() > 0 {
-		return eq.tryNextUnsafePayload(ctx)
+		return ErrNotEnoughData
 	}
 
 	if outOfData {
@@ -381,6 +410,7 @@ func (eq *EngineQueue) logSyncProgress(reason string) {
 		"l2_finalized", eq.finalized,
 		"l2_safe", eq.safeHead,
 		"l2_unsafe", eq.unsafeHead,
+		"l2_engineSyncTarget", eq.engineSyncTarget,
 		"l2_time", eq.unsafeHead.Time,
 		"l1_derived", eq.origin,
 	)
@@ -389,8 +419,11 @@ func (eq *EngineQueue) logSyncProgress(reason string) {
 // tryUpdateEngine attempts to update the engine with the current forkchoice state of the rollup node,
 // this is a no-op if the nodes already agree on the forkchoice state.
 func (eq *EngineQueue) tryUpdateEngine(ctx context.Context) error {
+	if eq.isEngineSyncing() {
+		eq.log.Warn("Attempting to update forkchoice state while engine is P2P syncing")
+	}
 	fc := eth.ForkchoiceState{
-		HeadBlockHash:      eq.unsafeHead.Hash,
+		HeadBlockHash:      eq.engineSyncTarget.Hash,
 		SafeBlockHash:      eq.safeHead.Hash,
 		FinalizedBlockHash: eq.finalized.Hash,
 	}
@@ -412,6 +445,26 @@ func (eq *EngineQueue) tryUpdateEngine(ctx context.Context) error {
 	return nil
 }
 
+// checkNewPayloadStatus checks returned status of engine_newPayloadV1 request for next unsafe payload.
+// It returns true if the status is acceptable.
+func (eq *EngineQueue) checkNewPayloadStatus(status eth.ExecutePayloadStatus) bool {
+	if eq.syncCfg.EngineSync {
+		// Allow SYNCING and ACCEPTED if engine P2P sync is enabled
+		return status == eth.ExecutionValid || status == eth.ExecutionSyncing || status == eth.ExecutionAccepted
+	}
+	return status == eth.ExecutionValid
+}
+
+// checkForkchoiceUpdatedStatus checks returned status of engine_forkchoiceUpdatedV1 request for next unsafe payload.
+// It returns true if the status is acceptable.
+func (eq *EngineQueue) checkForkchoiceUpdatedStatus(status eth.ExecutePayloadStatus) bool {
+	if eq.syncCfg.EngineSync {
+		// Allow SYNCING if engine P2P sync is enabled
+		return status == eth.ExecutionValid || status == eth.ExecutionSyncing
+	}
+	return status == eth.ExecutionValid
+}
+
 func (eq *EngineQueue) tryNextUnsafePayload(ctx context.Context) error {
 	first := eq.unsafePayloads.Peek()
 
@@ -427,8 +480,7 @@ func (eq *EngineQueue) tryNextUnsafePayload(ctx context.Context) error {
 	}
 
 	// Ensure that the unsafe payload builds upon the current unsafe head
-	// TODO: once we support snap-sync we can remove this condition, and handle the "SYNCING" status of the execution engine.
-	if first.ParentHash != eq.unsafeHead.Hash {
+	if !eq.syncCfg.EngineSync && first.ParentHash != eq.unsafeHead.Hash {
 		if uint64(first.BlockNumber) == eq.unsafeHead.Number+1 {
 			eq.log.Info("skipping unsafe payload, since it does not build onto the existing unsafe chain", "safe", eq.safeHead.ID(), "unsafe", first.ID(), "payload", first.ID())
 			eq.unsafePayloads.Pop()
@@ -447,7 +499,7 @@ func (eq *EngineQueue) tryNextUnsafePayload(ctx context.Context) error {
 	if err != nil {
 		return NewTemporaryError(fmt.Errorf("failed to update insert payload: %w", err))
 	}
-	if status.Status != eth.ExecutionValid {
+	if !eq.checkNewPayloadStatus(status.Status) {
 		eq.unsafePayloads.Pop()
 		return NewTemporaryError(fmt.Errorf("cannot process unsafe payload: new - %v; parent: %v; err: %w",
 			first.ID(), first.ParentID(), eth.NewPayloadErr(first, status)))
@@ -473,15 +525,20 @@ func (eq *EngineQueue) tryNextUnsafePayload(ctx context.Context) error {
 			return NewTemporaryError(fmt.Errorf("failed to update forkchoice to prepare for new unsafe payload: %w", err))
 		}
 	}
-	if fcRes.PayloadStatus.Status != eth.ExecutionValid {
+	if !eq.checkForkchoiceUpdatedStatus(fcRes.PayloadStatus.Status) {
 		eq.unsafePayloads.Pop()
 		return NewTemporaryError(fmt.Errorf("cannot prepare unsafe chain for new payload: new - %v; parent: %v; err: %w",
 			first.ID(), first.ParentID(), eth.ForkchoiceUpdateErr(fcRes.PayloadStatus)))
 	}
 
-	eq.unsafeHead = ref
+	eq.engineSyncTarget = ref
+	eq.metrics.RecordL2Ref("l2_engineSyncTarget", ref)
+	// unsafeHead should be updated only if the payload status is VALID
+	if fcRes.PayloadStatus.Status == eth.ExecutionValid {
+		eq.unsafeHead = ref
+		eq.metrics.RecordL2Ref("l2_unsafe", ref)
+	}
 	eq.unsafePayloads.Pop()
-	eq.metrics.RecordL2Ref("l2_unsafe", ref)
 	eq.log.Trace("Executed unsafe payload", "hash", ref.Hash, "number", ref.Number, "timestamp", ref.Time, "l1Origin", ref.L1Origin)
 	eq.logSyncProgress("unsafe payload from proposer")
 
@@ -514,7 +571,9 @@ func (eq *EngineQueue) tryNextSafeAttributes(ctx context.Context) error {
 		// For some reason the unsafe head is behind the safe head. Log it, and correct it.
 		eq.log.Error("invalid sync state, unsafe head is behind safe head", "unsafe", eq.unsafeHead, "safe", eq.safeHead)
 		eq.unsafeHead = eq.safeHead
+		eq.engineSyncTarget = eq.safeHead
 		eq.metrics.RecordL2Ref("l2_unsafe", eq.unsafeHead)
+		eq.metrics.RecordL2Ref("l2_engineSyncTarget", eq.engineSyncTarget)
 		return nil
 	}
 }
@@ -607,6 +666,9 @@ func (eq *EngineQueue) forceNextSafeAttributes(ctx context.Context) error {
 }
 
 func (eq *EngineQueue) StartPayload(ctx context.Context, parent eth.L2BlockRef, attrs *eth.PayloadAttributes, updateSafe bool) (errType BlockInsertionErrType, err error) {
+	if eq.isEngineSyncing() {
+		return BlockInsertTemporaryErr, fmt.Errorf("engine is in progess of p2p sync")
+	}
 	if eq.buildingID != (eth.PayloadID{}) {
 		eq.log.Warn("did not finish previous block building, starting new building now", "prev_onto", eq.buildingOnto, "prev_payload_id", eq.buildingID, "new_onto", parent)
 		// TODO: maybe worth it to force-cancel the old payload ID here.
@@ -648,7 +710,9 @@ func (eq *EngineQueue) ConfirmPayload(ctx context.Context) (out *eth.ExecutionPa
 	}
 
 	eq.unsafeHead = ref
+	eq.engineSyncTarget = ref
 	eq.metrics.RecordL2Ref("l2_unsafe", ref)
+	eq.metrics.RecordL2Ref("l2_engineSyncTarget", ref)
 
 	if eq.buildingSafe {
 		eq.safeHead = ref
@@ -689,7 +753,7 @@ func (eq *EngineQueue) resetBuildingState() {
 // Reset walks the L2 chain backwards until it finds an L2 block whose L1 origin is canonical.
 // The unsafe head is set to the head of the L2 chain, unless the existing safe head is not canonical.
 func (eq *EngineQueue) Reset(ctx context.Context, _ eth.L1BlockRef, _ eth.SystemConfig) error {
-	result, err := sync.FindL2Heads(ctx, eq.cfg, eq.l1Fetcher, eq.engine, eq.log)
+	result, err := sync.FindL2Heads(ctx, eq.cfg, eq.l1Fetcher, eq.engine, eq.log, eq.syncCfg)
 	if err != nil {
 		return NewTemporaryError(fmt.Errorf("failed to find the L2 Heads to start from: %w", err))
 	}
@@ -729,6 +793,7 @@ func (eq *EngineQueue) Reset(ctx context.Context, _ eth.L1BlockRef, _ eth.System
 	}
 	eq.log.Debug("Reset engine queue", "safeHead", safe, "unsafe", unsafe, "safe_timestamp", safe.Time, "unsafe_timestamp", unsafe.Time, "l1Origin", l1Origin)
 	eq.unsafeHead = unsafe
+	eq.engineSyncTarget = unsafe
 	eq.safeHead = safe
 	eq.safeAttributes = nil
 	eq.finalized = finalized
@@ -742,6 +807,7 @@ func (eq *EngineQueue) Reset(ctx context.Context, _ eth.L1BlockRef, _ eth.System
 	eq.metrics.RecordL2Ref("l2_finalized", finalized)
 	eq.metrics.RecordL2Ref("l2_safe", safe)
 	eq.metrics.RecordL2Ref("l2_unsafe", unsafe)
+	eq.metrics.RecordL2Ref("l2_engineSyncTarget", unsafe)
 	eq.logSyncProgress("reset derivation work")
 	return io.EOF
 }

--- a/components/node/rollup/derive/engine_queue_test.go
+++ b/components/node/rollup/derive/engine_queue_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kroma-network/kroma/components/node/eth"
 	"github.com/kroma-network/kroma/components/node/metrics"
 	"github.com/kroma-network/kroma/components/node/rollup"
+	"github.com/kroma-network/kroma/components/node/rollup/sync"
 	"github.com/kroma-network/kroma/components/node/testlog"
 	"github.com/kroma-network/kroma/components/node/testutils"
 )
@@ -246,7 +247,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 	prev := &fakeAttributesQueue{}
 
-	eq := NewEngineQueue(logger, cfg, eng, metrics, prev, l1F)
+	eq := NewEngineQueue(logger, cfg, eng, metrics, prev, l1F, &sync.Config{})
 	require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
 
 	require.Equal(t, refB1, eq.SafeL2Head(), "L2 reset should go back to proposer window ago: blocks with origin E and D are not safe until we reconcile, C is extra, and B1 is the end we look for")
@@ -481,7 +482,7 @@ func TestEngineQueue_ResetWhenUnsafeOriginNotCanonical(t *testing.T) {
 
 	prev := &fakeAttributesQueue{origin: refE}
 
-	eq := NewEngineQueue(logger, cfg, eng, metrics, prev, l1F)
+	eq := NewEngineQueue(logger, cfg, eng, metrics, prev, l1F, &sync.Config{})
 	require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
 
 	require.Equal(t, refB1, eq.SafeL2Head(), "L2 reset should go back to proposer window ago: blocks with origin E and D are not safe until we reconcile, C is extra, and B1 is the end we look for")
@@ -812,7 +813,7 @@ func TestVerifyNewL1Origin(t *testing.T) {
 			}, nil)
 
 			prev := &fakeAttributesQueue{origin: refE}
-			eq := NewEngineQueue(logger, cfg, eng, metrics, prev, l1F)
+			eq := NewEngineQueue(logger, cfg, eng, metrics, prev, l1F, &sync.Config{})
 			require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
 
 			require.Equal(t, refB1, eq.SafeL2Head(), "L2 reset should go back to proposer window ago: blocks with origin E and D are not safe until we reconcile, C is extra, and B1 is the end we look for")
@@ -910,7 +911,7 @@ func TestBlockBuildingRace(t *testing.T) {
 	}
 
 	prev := &fakeAttributesQueue{origin: refA, attrs: attrs}
-	eq := NewEngineQueue(logger, cfg, eng, metrics, prev, l1F)
+	eq := NewEngineQueue(logger, cfg, eng, metrics, prev, l1F, &sync.Config{})
 	require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
 
 	id := eth.PayloadID{0xff}
@@ -940,7 +941,7 @@ func TestBlockBuildingRace(t *testing.T) {
 	eng.ExpectGetPayload(id, nil, mockErr)
 	// The job will be not be cancelled, the untyped error is a temporary error
 
-	require.ErrorIs(t, eq.Step(context.Background()), NotEnoughData, "queue up attributes")
+	require.ErrorIs(t, eq.Step(context.Background()), ErrNotEnoughData, "queue up attributes")
 	require.ErrorIs(t, eq.Step(context.Background()), mockErr, "expecting to fail to process attributes")
 	require.NotNil(t, eq.safeAttributes, "still have attributes")
 
@@ -1085,14 +1086,15 @@ func TestResetLoop(t *testing.T) {
 
 	prev := &fakeAttributesQueue{origin: refA, attrs: attrs}
 
-	eq := NewEngineQueue(logger, cfg, eng, metrics.NoopMetrics, prev, l1F)
+	eq := NewEngineQueue(logger, cfg, eng, metrics.NoopMetrics, prev, l1F, &sync.Config{})
 	eq.unsafeHead = refA2
+	eq.engineSyncTarget = refA2
 	eq.safeHead = refA1
 	eq.finalized = refA0
 
 	// Queue up the safe attributes
 	require.Nil(t, eq.safeAttributes)
-	require.ErrorIs(t, eq.Step(context.Background()), NotEnoughData)
+	require.ErrorIs(t, eq.Step(context.Background()), ErrNotEnoughData)
 	require.NotNil(t, eq.safeAttributes)
 
 	// Perform the reset
@@ -1108,7 +1110,7 @@ func TestResetLoop(t *testing.T) {
 	require.NoError(t, eq.Step(context.Background()), "clean forkchoice state after reset")
 
 	// Crux of the test. Should be in a valid state after the reset.
-	require.ErrorIs(t, eq.Step(context.Background()), NotEnoughData, "Should be able to step after a reset")
+	require.ErrorIs(t, eq.Step(context.Background()), ErrNotEnoughData, "Should be able to step after a reset")
 
 	l1F.AssertExpectations(t)
 	eng.AssertExpectations(t)
@@ -1182,8 +1184,9 @@ func TestEngineQueue_StepPopOlderUnsafe(t *testing.T) {
 
 	prev := &fakeAttributesQueue{origin: refA}
 
-	eq := NewEngineQueue(logger, cfg, eng, metrics.NoopMetrics, prev, l1F)
+	eq := NewEngineQueue(logger, cfg, eng, metrics.NoopMetrics, prev, l1F, &sync.Config{})
 	eq.unsafeHead = refA2
+	eq.engineSyncTarget = refA2
 	eq.safeHead = refA0
 	eq.finalized = refA0
 

--- a/components/node/rollup/derive/error.go
+++ b/components/node/rollup/derive/error.go
@@ -89,10 +89,15 @@ func NewCriticalError(err error) error {
 
 // Sentinel errors, use these to get the severity of errors by calling
 // errors.Is(err, ErrTemporary) for example.
-var ErrTemporary = NewTemporaryError(nil)
-var ErrReset = NewResetError(nil)
-var ErrCritical = NewCriticalError(nil)
+var (
+	ErrTemporary = NewTemporaryError(nil)
+	ErrReset     = NewResetError(nil)
+	ErrCritical  = NewCriticalError(nil)
+)
 
-// NotEnoughData implies that the function currently does not have enough data to progress
+// ErrNotEnoughData implies that the function currently does not have enough data to progress
 // but if it is retried enough times, it will eventually return a real value or io.EOF
-var NotEnoughData = errors.New("not enough data")
+var ErrNotEnoughData = errors.New("not enough data")
+
+// ErrEngineP2PSyncing implies that the execution engine is currently in progress of P2P sync.
+var ErrEngineP2PSyncing = errors.New("engine is P2P syncing")

--- a/components/node/rollup/derive/frame_queue.go
+++ b/components/node/rollup/derive/frame_queue.go
@@ -48,7 +48,7 @@ func (fq *FrameQueue) NextFrame(ctx context.Context) (Frame, error) {
 	}
 	// If we did not add more frames but still have more data, retry this function.
 	if len(fq.frames) == 0 {
-		return Frame{}, NotEnoughData
+		return Frame{}, ErrNotEnoughData
 	}
 
 	ret := fq.frames[0]

--- a/components/node/rollup/derive/pipeline.go
+++ b/components/node/rollup/derive/pipeline.go
@@ -2,6 +2,7 @@ package derive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/kroma-network/kroma/components/node/eth"
 	"github.com/kroma-network/kroma/components/node/rollup"
+	"github.com/kroma-network/kroma/components/node/rollup/sync"
 )
 
 type Metrics interface {
@@ -46,6 +48,7 @@ type EngineQueueStage interface {
 	Finalized() eth.L2BlockRef
 	UnsafeL2Head() eth.L2BlockRef
 	SafeL2Head() eth.L2BlockRef
+	EngineSyncTarget() eth.L2BlockRef
 	Origin() eth.L1BlockRef
 	SystemConfig() eth.SystemConfig
 	SetUnsafeHead(head eth.L2BlockRef)
@@ -75,8 +78,7 @@ type DerivationPipeline struct {
 }
 
 // NewDerivationPipeline creates a derivation pipeline, which should be reset before use.
-func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetcher, engine Engine, metrics Metrics) *DerivationPipeline {
-
+func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetcher, engine Engine, metrics Metrics, syncCfg *sync.Config) *DerivationPipeline {
 	// Pull stages
 	l1Traversal := NewL1Traversal(log, cfg, l1Fetcher)
 	dataSrc := NewDataSourceFactory(log, cfg, l1Fetcher) // auxiliary stage for L1Retrieval
@@ -89,7 +91,7 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 	attributesQueue := NewAttributesQueue(log, cfg, attrBuilder, batchQueue)
 
 	// Step stages
-	eng := NewEngineQueue(log, cfg, engine, metrics, attributesQueue, l1Fetcher)
+	eng := NewEngineQueue(log, cfg, engine, metrics, attributesQueue, l1Fetcher, syncCfg)
 
 	// Reset from engine queue then up from L1 Traversal. The stages do not talk to each other during
 	// the reset, but after the engine queue, this is the order in which the stages could talk to each other.
@@ -147,6 +149,10 @@ func (dp *DerivationPipeline) UnsafeL2Head() eth.L2BlockRef {
 	return dp.eng.UnsafeL2Head()
 }
 
+func (dp *DerivationPipeline) EngineSyncTarget() eth.L2BlockRef {
+	return dp.eng.EngineSyncTarget()
+}
+
 func (dp *DerivationPipeline) StartPayload(ctx context.Context, parent eth.L2BlockRef, attrs *eth.PayloadAttributes, updateSafe bool) (errType BlockInsertionErrType, err error) {
 	return dp.eng.StartPayload(ctx, parent, attrs, updateSafe)
 }
@@ -199,6 +205,8 @@ func (dp *DerivationPipeline) Step(ctx context.Context) error {
 	if err := dp.eng.Step(ctx); err == io.EOF {
 		// If every stage has returned io.EOF, try to advance the L1 Origin
 		return dp.traversal.AdvanceL1Block(ctx)
+	} else if errors.Is(err, ErrEngineP2PSyncing) {
+		return err
 	} else if err != nil {
 		return fmt.Errorf("engine stage failed: %w", err)
 	} else {

--- a/components/node/rollup/sync/config.go
+++ b/components/node/rollup/sync/config.go
@@ -1,0 +1,8 @@
+package sync
+
+type Config struct {
+	// EngineSync is true when the EngineQueue can trigger execution engine P2P sync.
+	EngineSync bool `json:"engine_sync"`
+	// SkipSyncStartCheck skip the sanity check of consistency of L1 origins of the unsafe L2 blocks when determining the sync-starting point. This defers the L1-origin verification, and is recommended to use in when utilizing l2.engine-sync
+	SkipSyncStartCheck bool `json:"skip_sync_start_check"`
+}

--- a/components/node/rollup/sync/start.go
+++ b/components/node/rollup/sync/start.go
@@ -105,7 +105,7 @@ func currentHeads(ctx context.Context, cfg *rollup.Config, l2 L2Chain) (*FindHea
 // Plausible: meaning that the blockhash of the L2 block's L1 origin
 // (as reported in the L1 Attributes deposit within the L2 block) is not canonical at another height in the L1 chain,
 // and the same holds for all its ancestors.
-func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain, lgr log.Logger) (result *FindHeadsResult, err error) {
+func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain, lgr log.Logger, syncCfg *Config) (result *FindHeadsResult, err error) {
 	// Fetch current L2 forkchoice state
 	result, err = currentHeads(ctx, cfg, l2)
 	if err != nil {
@@ -173,18 +173,18 @@ func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain
 		if (n.Number == result.Finalized.Number) && (n.Hash != result.Finalized.Hash) {
 			return nil, fmt.Errorf("%w: finalized %s, got: %s", ErrReorgFinalized, result.Finalized, n)
 		}
-		// Check we are not reorging L2 incredibly deep
-		if n.L1Origin.Number+(MaxReorgProposerWindows*cfg.ProposerWindowSize) < prevUnsafe.L1Origin.Number {
-			// If the reorg depth is too large, something is fishy.
-			// This can legitimately happen if L1 goes down for a while. But in that case,
-			// restarting the L2 node with a bigger configured MaxReorgDepth is an acceptable
-			// stopgap solution.
-			return nil, fmt.Errorf("%w: traversed back to L2 block %s, but too deep compared to previous unsafe block %s", ErrReorgTooDeep, n, prevUnsafe)
-		}
 
 		// If we don't have a usable unsafe head, then set it
 		if result.Unsafe == (eth.L2BlockRef{}) {
 			result.Unsafe = n
+			// Check we are not reorging L2 incredibly deep
+			if n.L1Origin.Number+(MaxReorgProposerWindows*cfg.ProposerWindowSize) < prevUnsafe.L1Origin.Number {
+				// If the reorg depth is too large, something is fishy.
+				// This can legitimately happen if L1 goes down for a while. But in that case,
+				// restarting the L2 node with a bigger configured MaxReorgDepth is an acceptable
+				// stopgap solution.
+				return nil, fmt.Errorf("%w: traversed back to L2 block %s, but too deep compared to previous unsafe block %s", ErrReorgTooDeep, n, prevUnsafe)
+			}
 		}
 
 		if ahead {
@@ -215,6 +215,11 @@ func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain
 			return result, nil
 		}
 
+		if syncCfg.SkipSyncStartCheck && highestL2WithCanonicalL1Origin.Hash == n.Hash {
+			lgr.Info("Found highest L2 block with canonical L1 origin. Skip further sanity check and jump to the safe head")
+			n = result.Safe
+			continue
+		}
 		// Pull L2 parent for next iteration
 		parent, err := l2.L2BlockRefByHash(ctx, n.ParentHash)
 		if err != nil {

--- a/components/node/rollup/sync/start_test.go
+++ b/components/node/rollup/sync/start_test.go
@@ -77,7 +77,7 @@ func (c *syncStartTestCase) Run(t *testing.T) {
 	}
 	lgr := log.New()
 	lgr.SetHandler(log.DiscardHandler())
-	result, err := FindL2Heads(context.Background(), cfg, chain, chain, lgr)
+	result, err := FindL2Heads(context.Background(), cfg, chain, chain, lgr, &Config{})
 	if c.ExpectedErr != nil {
 		require.ErrorIs(t, err, c.ExpectedErr, "expected error")
 		return
@@ -286,6 +286,37 @@ func TestFindSyncStart(t *testing.T) {
 			ProposerWindowSize: 2,
 			SafeL2Head:         'D',
 			ExpectedErr:        ErrWrongChain,
+		},
+		{
+			// FindL2Heads() keeps walking back to safe head after finding canonical unsafe head
+			// ErrReorgTooDeep must not be raised
+			Name:               "long traverse to safe head",
+			GenesisL1Num:       0,
+			L1:                 "abcdefgh",
+			L2:                 "ABCDEFGH",
+			NewL1:              "abcdefgx",
+			PreFinalizedL2:     'B',
+			PreSafeL2:          'B',
+			GenesisL1:          'a',
+			GenesisL2:          'A',
+			UnsafeL2Head:       'G',
+			ProposerWindowSize: 1,
+			SafeL2Head:         'B',
+			ExpectedErr:        nil,
+		},
+		{
+			// L2 reorg is too deep
+			Name:               "reorg too deep",
+			GenesisL1Num:       0,
+			L1:                 "abcdefgh",
+			L2:                 "ABCDEFGH",
+			NewL1:              "abijklmn",
+			PreFinalizedL2:     'B',
+			PreSafeL2:          'B',
+			GenesisL1:          'a',
+			GenesisL2:          'A',
+			ProposerWindowSize: 1,
+			ExpectedErr:        ErrReorgTooDeep,
 		},
 	}
 

--- a/components/node/service.go
+++ b/components/node/service.go
@@ -19,6 +19,7 @@ import (
 	p2pcli "github.com/kroma-network/kroma/components/node/p2p/cli"
 	"github.com/kroma-network/kroma/components/node/rollup"
 	"github.com/kroma-network/kroma/components/node/rollup/driver"
+	"github.com/kroma-network/kroma/components/node/rollup/sync"
 	"github.com/kroma-network/kroma/components/node/sources"
 	kpprof "github.com/kroma-network/kroma/utils/service/pprof"
 )
@@ -55,6 +56,8 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 
 	l2SyncEndpoint := NewL2SyncEndpointConfig(ctx)
 
+	syncConfig := NewSyncConfig(ctx)
+
 	cfg := &node.Config{
 		L1:     l1Endpoint,
 		L2:     l2Endpoint,
@@ -84,6 +87,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 			Moniker: ctx.String(flags.HeartbeatMonikerFlag.Name),
 			URL:     ctx.String(flags.HeartbeatURLFlag.Name),
 		},
+		Sync: *syncConfig,
 	}
 	if err := cfg.Check(); err != nil {
 		return nil, err
@@ -190,4 +194,11 @@ func NewSnapshotLogger(ctx *cli.Context) (log.Logger, error) {
 	logger := log.New()
 	logger.SetHandler(handler)
 	return logger, nil
+}
+
+func NewSyncConfig(ctx *cli.Context) *sync.Config {
+	return &sync.Config{
+		EngineSync:         ctx.Bool(flags.L2EngineSyncEnabled.Name),
+		SkipSyncStartCheck: ctx.Bool(flags.SkipSyncStartCheck.Name),
+	}
 }

--- a/components/node/testutils/random.go
+++ b/components/node/testutils/random.go
@@ -262,6 +262,7 @@ func RandomOutputResponse(rng *rand.Rand) *eth.OutputResponse {
 			UnsafeL2:           RandomL2BlockRef(rng),
 			SafeL2:             RandomL2BlockRef(rng),
 			FinalizedL2:        RandomL2BlockRef(rng),
+			EngineSyncTarget:   RandomL2BlockRef(rng),
 		},
 	}
 }

--- a/e2e/actions/l2_batcher_test.go
+++ b/e2e/actions/l2_batcher_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kroma-network/kroma/components/node/eth"
 	"github.com/kroma-network/kroma/components/node/rollup/derive"
+	"github.com/kroma-network/kroma/components/node/rollup/sync"
 	"github.com/kroma-network/kroma/components/node/testlog"
 	"github.com/kroma-network/kroma/e2e/e2eutils"
 )
@@ -30,7 +31,7 @@ func TestBatcher(gt *testing.T) {
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
 	miner, propEngine, proposer := setupProposerTest(t, sd, log)
-	syncEngine, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg))
+	syncEngine, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg), &sync.Config{})
 
 	rollupPropCl := proposer.RollupClient()
 	batcher := NewL2Batcher(log, sd.RollupCfg, &BatcherCfg{
@@ -271,7 +272,7 @@ func TestGarbageBatch(gt *testing.T) {
 		log := testlog.Logger(t, log.LvlError)
 		miner, engine, proposer := setupProposerTest(t, sd, log)
 
-		_, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg))
+		_, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg), &sync.Config{})
 
 		batcherCfg := &BatcherCfg{
 			MinL1TxSize: 0,
@@ -353,7 +354,7 @@ func TestExtendedTimeWithoutL1Batches(gt *testing.T) {
 	log := testlog.Logger(t, log.LvlError)
 	miner, engine, proposer := setupProposerTest(t, sd, log)
 
-	_, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg))
+	_, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg), &sync.Config{})
 
 	batcher := NewL2Batcher(log, sd.RollupCfg, &BatcherCfg{
 		MinL1TxSize: 0,
@@ -410,7 +411,7 @@ func TestBigL2Txs(gt *testing.T) {
 	log := testlog.Logger(t, log.LvlInfo)
 	miner, engine, proposer := setupProposerTest(t, sd, log)
 
-	_, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg))
+	_, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg), &sync.Config{})
 
 	batcher := NewL2Batcher(log, sd.RollupCfg, &BatcherCfg{
 		MinL1TxSize: 0,

--- a/e2e/actions/l2_proposer.go
+++ b/e2e/actions/l2_proposer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kroma-network/kroma/components/node/rollup"
 	"github.com/kroma-network/kroma/components/node/rollup/derive"
 	"github.com/kroma-network/kroma/components/node/rollup/driver"
+	"github.com/kroma-network/kroma/components/node/rollup/sync"
 	"github.com/kroma-network/kroma/components/node/sources"
 	"github.com/kroma-network/kroma/e2e/e2eutils"
 )
@@ -42,7 +43,7 @@ type L2Proposer struct {
 }
 
 func NewL2Proposer(t Testing, log log.Logger, l1 derive.L1Fetcher, eng L2API, cfg *rollup.Config, propConfDepth uint64) *L2Proposer {
-	syncer := NewL2Syncer(t, log, l1, eng, cfg)
+	syncer := NewL2Syncer(t, log, l1, eng, cfg, &sync.Config{})
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, eng)
 	propConfDepthL1 := driver.NewConfDepth(propConfDepth, syncer.l1State.L1Head, l1)
 	l1OriginSelector := &MockL1OriginSelector{

--- a/e2e/actions/l2_syncer_test.go
+++ b/e2e/actions/l2_syncer_test.go
@@ -8,22 +8,23 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kroma-network/kroma/components/node/rollup/derive"
+	"github.com/kroma-network/kroma/components/node/rollup/sync"
 	"github.com/kroma-network/kroma/components/node/testlog"
 	"github.com/kroma-network/kroma/e2e/e2eutils"
 )
 
-func setupSyncer(t Testing, sd *e2eutils.SetupData, log log.Logger, l1F derive.L1Fetcher) (*L2Engine, *L2Syncer) {
+func setupSyncer(t Testing, sd *e2eutils.SetupData, log log.Logger, l1F derive.L1Fetcher, syncCfg *sync.Config) (*L2Engine, *L2Syncer) {
 	jwtPath := e2eutils.WriteDefaultJWT(t)
 	engine := NewL2Engine(t, log, sd.L2Cfg, sd.RollupCfg.Genesis.L1, jwtPath)
 	engCl := engine.EngineClient(t, sd.RollupCfg)
-	syncer := NewL2Syncer(t, log, l1F, engCl, sd.RollupCfg)
+	syncer := NewL2Syncer(t, log, l1F, engCl, sd.RollupCfg, syncCfg)
 	return engine, syncer
 }
 
 func setupSyncerOnlyTest(t Testing, sd *e2eutils.SetupData, log log.Logger) (*L1Miner, *L2Engine, *L2Syncer) {
 	miner := NewL1Miner(t, log, sd.L1Cfg)
 	l1Cl := miner.L1Client(t, sd.RollupCfg)
-	engine, syncer := setupSyncer(t, sd, log, l1Cl)
+	engine, syncer := setupSyncer(t, sd, log, l1Cl, &sync.Config{})
 	return miner, engine, syncer
 }
 

--- a/e2e/actions/reorg_test.go
+++ b/e2e/actions/reorg_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kroma-network/kroma/components/node/client"
 	"github.com/kroma-network/kroma/components/node/eth"
+	"github.com/kroma-network/kroma/components/node/rollup/sync"
 	"github.com/kroma-network/kroma/components/node/sources"
 	"github.com/kroma-network/kroma/components/node/testlog"
 	"github.com/kroma-network/kroma/e2e/e2eutils"
@@ -33,7 +34,7 @@ func setupReorgTestActors(t Testing, dp *e2eutils.DeployParams, sd *e2eutils.Set
 	miner, propEngine, proposer := setupProposerTest(t, sd, log)
 	miner.ActL1SetFeeRecipient(common.Address{'A'})
 	proposer.ActL2PipelineFull(t)
-	syncEngine, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg))
+	syncEngine, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg), &sync.Config{})
 	rollupPropCl := proposer.RollupClient()
 	batcher := NewL2Batcher(log, sd.RollupCfg, &BatcherCfg{
 		MinL1TxSize: 0,

--- a/e2e/actions/sync_test.go
+++ b/e2e/actions/sync_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kroma-network/kroma/components/node/eth"
 	"github.com/kroma-network/kroma/components/node/rollup/derive"
+	"github.com/kroma-network/kroma/components/node/rollup/sync"
+	"github.com/kroma-network/kroma/components/node/sources"
 	"github.com/kroma-network/kroma/components/node/testlog"
 	"github.com/kroma-network/kroma/e2e/e2eutils"
 )
@@ -93,4 +96,75 @@ func TestFinalizeWhileSyncing(gt *testing.T) {
 
 	// Verify the syncer finalized something new
 	require.Less(t, syncerStartStatus.FinalizedL2.Number, syncer.SyncStatus().FinalizedL2.Number, "syncer finalized L2 blocks during sync")
+}
+
+func TestUnsafeSync(gt *testing.T) {
+	t := NewDefaultTesting(gt)
+	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
+	sd := e2eutils.Setup(t, dp, defaultAlloc)
+	log := testlog.Logger(t, log.LvlInfo)
+
+	sd, _, _, proposer, propEng, syncer, _, _ := setupReorgTestActors(t, dp, sd, log)
+	propEngCl, err := sources.NewEngineClient(propEng.RPCClient(), log, nil, sources.EngineClientDefaultConfig(sd.RollupCfg))
+	require.NoError(t, err)
+
+	proposer.ActL2PipelineFull(t)
+	syncer.ActL2PipelineFull(t)
+
+	for i := 0; i < 10; i++ {
+		// Build a L2 block
+		proposer.ActL2StartBlock(t)
+		proposer.ActL2EndBlock(t)
+		// Notify new L2 block to syncer by unsafe gossip
+		propHead, err := propEngCl.PayloadByLabel(t.Ctx(), eth.Unsafe)
+		require.NoError(t, err)
+		syncer.ActL2UnsafeGossipReceive(propHead)(t)
+		// Handle unsafe payload
+		syncer.ActL2PipelineFull(t)
+		// Syncer must advance its unsafe head and engine sync target.
+		require.Equal(t, proposer.L2Unsafe().Hash, syncer.L2Unsafe().Hash)
+		// Check engine sync target updated.
+		require.Equal(t, proposer.L2Unsafe().Hash, proposer.EngineSyncTarget().Hash)
+		require.Equal(t, syncer.L2Unsafe().Hash, syncer.EngineSyncTarget().Hash)
+	}
+}
+
+func TestEngineP2PSync(gt *testing.T) {
+	t := NewDefaultTesting(gt)
+	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
+	sd := e2eutils.Setup(t, dp, defaultAlloc)
+	log := testlog.Logger(t, log.LvlInfo)
+
+	miner, propEng, proposer := setupProposerTest(t, sd, log)
+	// Enable engine P2P sync
+	_, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg), &sync.Config{EngineSync: true})
+
+	propEngCl, err := sources.NewEngineClient(propEng.RPCClient(), log, nil, sources.EngineClientDefaultConfig(sd.RollupCfg))
+	require.NoError(t, err)
+
+	proposer.ActL2PipelineFull(t)
+	syncer.ActL2PipelineFull(t)
+
+	syncerUnsafeHead := syncer.L2Unsafe()
+
+	// Build a L2 block. This block will not be gossiped to syncer, so syncer can not advance chain by itself.
+	proposer.ActL2StartBlock(t)
+	proposer.ActL2EndBlock(t)
+
+	for i := 0; i < 10; i++ {
+		// Build a L2 block
+		proposer.ActL2StartBlock(t)
+		proposer.ActL2EndBlock(t)
+		// Notify new L2 block to syncer by unsafe gossip
+		propHead, err := propEngCl.PayloadByLabel(t.Ctx(), eth.Unsafe)
+		require.NoError(t, err)
+		syncer.ActL2UnsafeGossipReceive(propHead)(t)
+		// Handle unsafe payload
+		syncer.ActL2PipelineFull(t)
+		// Syncer must advance only engine sync target.
+		require.NotEqual(t, proposer.L2Unsafe().Hash, syncer.L2Unsafe().Hash)
+		require.NotEqual(t, syncer.L2Unsafe().Hash, syncer.EngineSyncTarget().Hash)
+		require.Equal(t, syncer.L2Unsafe().Hash, syncerUnsafeHead.Hash)
+		require.Equal(t, proposer.L2Unsafe().Hash, syncer.EngineSyncTarget().Hash)
+	}
 }

--- a/e2e/actions/system_config_test.go
+++ b/e2e/actions/system_config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kroma-network/kroma/bindings/bindings"
 	"github.com/kroma-network/kroma/components/node/eth"
 	"github.com/kroma-network/kroma/components/node/rollup/derive"
+	"github.com/kroma-network/kroma/components/node/rollup/sync"
 	"github.com/kroma-network/kroma/components/node/testlog"
 	"github.com/kroma-network/kroma/e2e/e2eutils"
 )
@@ -29,7 +30,7 @@ func TestBatcherKeyRotation(gt *testing.T) {
 	miner, propEngine, proposer := setupProposerTest(t, sd, log)
 	miner.ActL1SetFeeRecipient(common.Address{'A'})
 	proposer.ActL2PipelineFull(t)
-	_, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg))
+	_, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg), &sync.Config{})
 	rollupPropCl := proposer.RollupClient()
 
 	// the default batcher
@@ -349,7 +350,7 @@ func TestGasLimitChange(gt *testing.T) {
 	miner.ActL1IncludeTx(dp.Addresses.Batcher)(t)
 	miner.ActL1EndBlock(t)
 
-	_, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg))
+	_, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg), &sync.Config{})
 	syncer.ActL2PipelineFull(t)
 
 	require.Equal(t, proposer.L2Unsafe(), syncer.L2Safe(), "syncer stays in sync, even with gaslimit changes")
@@ -424,7 +425,7 @@ func TestValidatorRewardScalarChange(gt *testing.T) {
 	miner.ActL1IncludeTx(dp.Addresses.Batcher)(t)
 	miner.ActL1EndBlock(t)
 
-	_, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg))
+	_, syncer := setupSyncer(t, sd, log, miner.L1Client(t, sd.RollupCfg), &sync.Config{})
 	syncer.ActL2PipelineFull(t)
 
 	require.Equal(t, proposer.L2Unsafe(), syncer.L2Safe(), "syncer stays in sync, even with validator reward scalar changes")

--- a/specs/exec-engine.md
+++ b/specs/exec-engine.md
@@ -232,7 +232,7 @@ as the engine implementation can sync state faster through methods like [snap-sy
 ### Happy-path sync
 
 1. The rollup node informs the engine of the L2 chain head, unconditionally (part of regular node operation):
-   - [`engine_newPayloadV1`][engine_newPayloadV1] is called with latest L2 block derived from L1.
+   - [`engine_newPayloadV1`][engine_newPayloadV1] is called with latest L2 block received from P2P.
    - [`engine_forkchoiceUpdatedV1`][engine_forkchoiceUpdatedV1] is called with the current
      `unsafe`/`safe`/`finalized` L2 block hashes.
 2. The engine requests headers from peers, in reverse till the parent hash matches the local chain


### PR DESCRIPTION
# Description

Enable to trigger the Execution Engine’s P2P sync for a faster sync and [Happy-path sync](https://github.com/kroma-network/kroma/blob/dev/specs/exec-engine.md#happy-path-sync) with newly introduced flag `L2_ENGINE_SYNC_ENABLED`.
Also there is another related [branch](https://github.com/kroma-network/go-ethereum/tree/snapsync) in kroma-geth repository to support snap sync.

See Optimism PR#6243.
