### PR TITLE
feat(validator): add gas limit margin when submitting output

### DIFF
--- a/components/validator/validator.go
+++ b/components/validator/validator.go
@@ -53,7 +53,7 @@ func Main(version string, cliCtx *cli.Context) error {
 	m.RecordInfo(version)
 	m.RecordUp()
 
-	validator, err := NewValidator(ctx, *validatorCfg, l, m)
+	validator, err := NewValidator(*validatorCfg, l, m)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ type Validator struct {
 	l2ooContract *bindings.L2OutputOracleCaller
 }
 
-func NewValidator(ctx context.Context, cfg Config, l log.Logger, m metrics.Metricer) (*Validator, error) {
+func NewValidator(cfg Config, l log.Logger, m metrics.Metricer) (*Validator, error) {
 	// Validate the validator config
 	if err := cfg.Check(); err != nil {
 		return nil, err

--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -138,9 +138,9 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 		GasPriceOracleScalar:   1_000_000,
 		ValidatorRewardScalar:  5000,
 
-		ProxyAdminOwner:              addresses.ProxyAdminOwner,
-		ProtocolVaultRecipient:       common.Address{19: 2},
-		L1FeeVaultRecipient:       common.Address{19: 3},
+		ProxyAdminOwner:        addresses.ProxyAdminOwner,
+		ProtocolVaultRecipient: common.Address{19: 2},
+		L1FeeVaultRecipient:    common.Address{19: 3},
 
 		DeploymentWaitConfirmations: 1,
 
@@ -643,7 +643,7 @@ func (cfg SystemConfig) Start(_opts ...SystemConfigOption) (*System, error) {
 		validatorMaliciousL2RPC.SetTargetBlockNumber(testdata.TargetBlockNumber)
 	}
 
-	sys.Validator, err = validator.NewValidator(context.Background(), *validatorCfg, sys.cfg.Loggers["validator"], validatormetrics.NoopMetrics)
+	sys.Validator, err = validator.NewValidator(*validatorCfg, sys.cfg.Loggers["validator"], validatormetrics.NoopMetrics)
 	if err != nil {
 		return nil, fmt.Errorf("unable to setup validator: %w", err)
 	}
@@ -695,7 +695,7 @@ func (cfg SystemConfig) Start(_opts ...SystemConfigOption) (*System, error) {
 
 	// Replace to mock fetcher
 	challengerCfg.ProofFetcher = e2eutils.NewFetcher(sys.cfg.Loggers["challenger"], "./testdata/proof")
-	sys.Challenger, err = validator.NewValidator(context.Background(), *challengerCfg, sys.cfg.Loggers["challenger"], validatormetrics.NoopMetrics)
+	sys.Challenger, err = validator.NewValidator(*challengerCfg, sys.cfg.Loggers["challenger"], validatormetrics.NoopMetrics)
 	if err != nil {
 		return nil, fmt.Errorf("unable to setup challenger: %w", err)
 	}

--- a/utils/service/txmgr/price_bump_test.go
+++ b/utils/service/txmgr/price_bump_test.go
@@ -21,7 +21,7 @@ type priceBumpTest struct {
 }
 
 func (tc *priceBumpTest) run(t *testing.T) {
-	prevFC := calcGasFeeCap(big.NewInt(tc.prevBasefee), big.NewInt(tc.prevGasTip))
+	prevFC := CalcGasFeeCap(big.NewInt(tc.prevBasefee), big.NewInt(tc.prevGasTip))
 	lgr := testlog.Logger(t, log.LvlCrit)
 
 	tip, fc := updateFees(big.NewInt(tc.prevGasTip), prevFC, big.NewInt(tc.newGasTip), big.NewInt(tc.newBasefee), lgr)

--- a/utils/service/txmgr/txmgr_test.go
+++ b/utils/service/txmgr/txmgr_test.go
@@ -124,7 +124,7 @@ func (g *gasPricer) shouldMine(gasFeeCap *big.Int) bool {
 func (g *gasPricer) feesForEpoch(epoch int64) (*big.Int, *big.Int) {
 	epochBaseFee := new(big.Int).Mul(g.baseBaseFee, big.NewInt(epoch))
 	epochGasTipCap := new(big.Int).Mul(g.baseGasTipFee, big.NewInt(epoch))
-	epochGasFeeCap := calcGasFeeCap(epochBaseFee, epochGasTipCap)
+	epochGasFeeCap := CalcGasFeeCap(epochBaseFee, epochGasTipCap)
 
 	return epochGasTipCap, epochGasFeeCap
 }
@@ -820,7 +820,7 @@ func TestIncreaseGasPriceNotExponential(t *testing.T) {
 		gasTip:  big.NewInt(10),
 		baseFee: big.NewInt(45),
 	}
-	feeCap := calcGasFeeCap(borkedBackend.baseFee, borkedBackend.gasTip)
+	feeCap := CalcGasFeeCap(borkedBackend.baseFee, borkedBackend.gasTip)
 
 	mgr := &SimpleTxManager{
 		Config: Config{


### PR DESCRIPTION
# Description

Since we have dynamic gas usage in unbond and priority validator selection logic, it is hard to estimate exact gas usage. This leads to frequent transaction failures, so to avoid this, set the output submission gas limit `1.5 * estimated gas`.
