### PR TITLE
feat(node): set block topic to kroma (gossip)

### DIFF
--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -66,7 +66,7 @@ type GossipMetricer interface {
 }
 
 func blocksTopicV1(cfg *rollup.Config) string {
-	return fmt.Sprintf("/optimism/%s/0/blocks", cfg.L2ChainID.String())
+	return fmt.Sprintf("/kroma/%s/0/blocks", cfg.L2ChainID.String())
 }
 
 // BuildSubscriptionFilter builds a simple subscription filter,


### PR DESCRIPTION
# Description

Rename the block topic in gossip p2p, which was modified in the OP upstream, back to kroma.
This is to maintain backward compatibility for existing p2p nodes.