### PR TITLE
chore(contracts): make `_processWithdrawal()` be virtual for overriding

### DIFF
--- a/packages/contracts/contracts/L2/ValidatorRewardVault.sol
+++ b/packages/contracts/contracts/L2/ValidatorRewardVault.sol
@@ -99,7 +99,7 @@ contract ValidatorRewardVault is FeeVault, Semver {
      * @notice Checks if the withdrawal is possible, and returns the withdrawal amount.
      *         When a withdrawal is available, it resets the balance and updates the total processed amount.
      */
-    function _processWithdrawal() internal returns (uint256) {
+    function _processWithdrawal() internal override returns (uint256) {
         uint256 amount = rewards[msg.sender];
         require(
             amount >= MIN_WITHDRAWAL_AMOUNT,

--- a/packages/contracts/contracts/universal/FeeVault.sol
+++ b/packages/contracts/contracts/universal/FeeVault.sol
@@ -58,7 +58,7 @@ abstract contract FeeVault {
      * @notice Checks if the withdrawal is possible, and returns the withdrawal amount.
      *         When a withdrawal is available, it resets the balance and updates the total processed amount.
      */
-    function _processWithdrawal() private returns (uint256) {
+    function _processWithdrawal() internal virtual returns (uint256) {
         require(
             address(this).balance >= MIN_WITHDRAWAL_AMOUNT,
             "FeeVault: withdrawal amount must be greater than minimum withdrawal amount"


### PR DESCRIPTION
Fixed error in build contracts: https://github.com/kroma-network/kroma/actions/runs/7162496625/job/19499546642.
I made the `_processWithdrawal` be virtural in `FeeVault.sol`, and overrode this in `ValidatorRewardVault.sol`.
