### PR TITLE
build: specify multiplatform in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.21.1-alpine3.18 as builder
+FROM golang:1.21.1-alpine3.18 as builder
 RUN apk add --no-cache gcc git make musl-dev
 
 COPY ./go.mod /app/go.mod


### PR DESCRIPTION
# Description

Fixed an issue with Alpine images not having the desired multiplatform compatibility behavior.

Specify multiplatform in docker build.

