### PR TITLE
docs: fix incorrect demonstration

### DIFF
--- a/specs/challenge.md
+++ b/specs/challenge.md
@@ -48,8 +48,6 @@ In the ZK fault-proof challenge process, the following undeniable bug might aris
 
 - The deletion of a valid output due to two valid and contradictory zk proofs
 - The failure to delete an invalid output due to the bugs in prover/verifier or ZK completeness error
-- The deletion of a valid output due to two valid and contradictory ZK proofs
-- The failure to delete an invalid output due to the bugs in prover/verifier or ZK completeness error
 
 In the former case, the Security Council validates the legitimacy of the deleted output and, if the aforementioned
 error is identified, dismisses the challenge and initiates a rollback of the deleted output.

--- a/specs/challenge.md
+++ b/specs/challenge.md
@@ -46,7 +46,7 @@ the challenges are canceled, and staked bonds are refunded to the respective cha
 In the ZK fault-proof challenge process, the following undeniable bug might arise, prompting the intervention of the
 [Security Council][g-security-council]:
 
-- The deletion of a valid output due to two valid and contradictory zk proofs
+- The deletion of a valid output due to two valid and contradictory ZK proofs
 - The failure to delete an invalid output due to the bugs in prover/verifier or ZK completeness error
 
 In the former case, the Security Council validates the legitimacy of the deleted output and, if the aforementioned

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -198,8 +198,8 @@ correctly), and so are individual transactions within the batch (e.g. signatures
 invalid individual transactions within an otherwise valid batch are discarded by correct nodes.
 
 If the validator applies a state transition incorrectly and posts an [output root][g-l2-output], then this output root
-will be incorrect. The incorrect output root will be challenged by a [ZK fault proof][g-zk-fault-proof], and
-subsequently removed.
+will be incorrect. The incorrect output root will be challenged by a [ZK fault proof][g-zk-fault-proof], and once proven
+incorrect, it will be deleted.
 
 Refer to the [Batch Submission specification][batcher-spec] for more information.
 

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -198,8 +198,8 @@ correctly), and so are individual transactions within the batch (e.g. signatures
 invalid individual transactions within an otherwise valid batch are discarded by correct nodes.
 
 If the validator applies a state transition incorrectly and posts an [output root][g-l2-output], then this output root
-will be incorrect. The incorrect output root which will be challenged by a [ZK fault proof][g-zk-fault-proof],
-then replaced by a correct output root **for the existing sequencer batches.**
+will be incorrect. The incorrect output root will be challenged by a [ZK fault proof][g-zk-fault-proof], and
+subsequently removed.
 
 Refer to the [Batch Submission specification][batcher-spec] for more information.
 

--- a/specs/glossary.md
+++ b/specs/glossary.md
@@ -886,7 +886,7 @@ invalid [L2 output roots][l2-output].
 
 [zk-fault-proof]: glossary.md#zk-fault-proof
 
-An on-chain _interactive_ proof, performed by [validators][validator], that demonstrates that a [sequencer] provided
+An on-chain *interactive* proof, performed by [validators][validator], that demonstrates that a [sequencer] provided
 erroneous [output roots][l2-output] using zkEVM.
 
 ## Security Council


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the challenge process details to remove ambiguity about the handling of duplicate lines and invalid outputs.
	- Clarified the validator's actions regarding incorrect output roots in the derivation documentation.
	- Enhanced the glossary with a definition and explanation of on-chain interactive proofs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->