### PR TITLE
fix: add blob related things to rpc header

### DIFF
--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -136,7 +136,16 @@ type rpcHeader struct {
 	BaseFee *hexutil.Big `json:"baseFeePerGas"`
 
 	// WithdrawalsRoot was added by EIP-4895 and is ignored in legacy headers.
-	WithdrawalsRoot *common.Hash `json:"withdrawalsRoot"`
+	WithdrawalsRoot *common.Hash `json:"withdrawalsRoot,omitempty"`
+
+	// BlobGasUsed was added by EIP-4844 and is ignored in legacy headers.
+	BlobGasUsed *hexutil.Uint64 `json:"blobGasUsed,omitempty"`
+
+	// ExcessBlobGas was added by EIP-4844 and is ignored in legacy headers.
+	ExcessBlobGas *hexutil.Uint64 `json:"excessBlobGas,omitempty"`
+
+	// ParentBeaconRoot was added by EIP-4788 and is ignored in legacy headers.
+	ParentBeaconRoot *common.Hash `json:"parentBeaconBlockRoot,omitempty"`
 
 	// untrusted info included by RPC, may have to be checked
 	Hash common.Hash `json:"hash"`
@@ -189,6 +198,10 @@ func (hdr *rpcHeader) createGethHeader() *types.Header {
 		Nonce:           hdr.Nonce,
 		BaseFee:         (*big.Int)(hdr.BaseFee),
 		WithdrawalsHash: hdr.WithdrawalsRoot,
+		// Cancun
+		BlobGasUsed:      (*uint64)(hdr.BlobGasUsed),
+		ExcessBlobGas:    (*uint64)(hdr.ExcessBlobGas),
+		ParentBeaconRoot: hdr.ParentBeaconRoot,
 	}
 }
 


### PR DESCRIPTION
Merge into `release/v1.1.1-base` branch, which is a base branch for releasing `v1.1.1`. 
With dencun upgrade, blob related fields are added to block header. 
Accordingly, those should be added. Without this, the validation of block header when starting node is failed.

```
msg="failed to fetch L1 head for runtime config initialization" err=failed to fetch head header:  failed to verify block hash: computed 0xaaa but RPC said 0xbbb"
```

After merging this PR, `v1.1.1` will be released. Also, this should be applied to `v1.2.0-rc.*`, where the upstreamed version is v1.3.0, since this is added in Optimism `v1.4.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the data structure to include new fields for enhanced transaction processing and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->