### PR TITLE
chore: enable canyon upgrade for kroma sepolia

### DIFF
--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -72,7 +72,7 @@ var Sepolia = &rollup.Config{
 	DepositContractAddress: common.HexToAddress("0x31ab8ed993a3be9aa2757c7d368dc87101a868a4"),
 	L1SystemConfigAddress:  common.HexToAddress("0x398c8ea789968893095d86cba168378a4f452e33"),
 	RegolithTime:           u64Ptr(0),
-	CanyonTime:             nil,
+	CanyonTime:             u64Ptr(1707897600),
 	DeltaTime:              nil,
 }
 

--- a/op-node/chaincfg/chains_test.go
+++ b/op-node/chaincfg/chains_test.go
@@ -99,6 +99,6 @@ var sepoliaCfg = rollup.Config{
 	DepositContractAddress: common.HexToAddress("0x31ab8ed993a3be9aa2757c7d368dc87101a868a4"),
 	L1SystemConfigAddress:  common.HexToAddress("0x398c8ea789968893095d86cba168378a4f452e33"),
 	RegolithTime:           u64Ptr(0),
-	CanyonTime:             nil,
+	CanyonTime:             u64Ptr(1707897600),
 	DeltaTime:              nil,
 }


### PR DESCRIPTION
# Description

This PR with commits that updated the Canyon upgrade activation time for kroma-sepolia.
The activation time for kroma-sepolia is 1707897600
At the same time as the Canyon upgrade, the Shanghai upgrade is also activated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the `CanyonTime` configuration for the Sepolia network to ensure accurate timing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->