### PR TITLE
chore: fix to record deposit amount less than required amount

### DIFF
--- a/kroma-validator/challenger.go
+++ b/kroma-validator/challenger.go
@@ -606,13 +606,13 @@ func (c *Challenger) HasEnoughDeposit(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to fetch deposit amount: %w", err)
 	}
+	c.metr.RecordDepositAmount(balance)
 
 	if balance.Cmp(c.requiredBondAmount) == -1 {
 		c.log.Warn("deposit is less than bond amount", "required", c.requiredBondAmount, "deposit", balance)
 		return false, nil
 	}
 	c.log.Info("deposit amount and bond amount", "deposit", balance, "bond", c.requiredBondAmount)
-	c.metr.RecordDepositAmount(balance)
 
 	return true, nil
 }

--- a/kroma-validator/l2_output_submitter.go
+++ b/kroma-validator/l2_output_submitter.go
@@ -277,6 +277,7 @@ func (l *L2OutputSubmitter) HasEnoughDeposit(ctx context.Context) (bool, error) 
 	if err != nil {
 		return false, fmt.Errorf("failed to fetch deposit amount: %w", err)
 	}
+	l.metr.RecordDepositAmount(balance)
 
 	if balance.Cmp(l.requiredBondAmount) == -1 {
 		l.log.Warn(
@@ -287,7 +288,6 @@ func (l *L2OutputSubmitter) HasEnoughDeposit(ctx context.Context) (bool, error) 
 		return false, nil
 	}
 	l.log.Info("deposit amount", "deposit", balance)
-	l.metr.RecordDepositAmount(balance)
 
 	return true, nil
 }


### PR DESCRIPTION
Make l2 output submitter and challenger record the deposit balance even if the balance is less than the required bond amount. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the deposit handling process to ensure deposit amounts are recorded prior to comparison checks in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->