### PR TITLE
feat(node): append mint token tx to payload attributes

### DIFF
--- a/kroma-chain-ops/genesis/testdata/test-deploy-config-devnet-l1.json
+++ b/kroma-chain-ops/genesis/testdata/test-deploy-config-devnet-l1.json
@@ -53,5 +53,16 @@
   "colosseumSegmentsLengths": "2,2,3,3",
   "zkVerifierHashScalar": "0x1545b1bf82c58ee35648bd877da9c5010193e82b036b16bf382acf31bc2ab576",
   "zkVerifierM56Px": "0x15ae1a8e3b993dd9aadc8f9086d1ea239d4cd5c09cfa445f337e1b60d7b3eb87",
-  "zkVerifierM56Py": "0x2c702ede24f9db8c8c9a439975facd3872a888c5f84f58b3b5f5a5623bac945a"
+  "zkVerifierM56Py": "0x2c702ede24f9db8c8c9a439975facd3872a888c5f84f58b3b5f5a5623bac945a",
+  "l2GenesisBurgundyTimeOffset": "0x0",
+  "mintManagerSlidingWindowBlocks": 3888000,
+  "mintManagerDecayingFactor": 92224,
+  "mintManagerRecipients": [
+    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "0x4200000000000000000000000000000000000008"
+  ],
+  "mintManagerShares": [
+    700000,
+    300000
+  ]
 }

--- a/op-e2e/actions/span_batch_test.go
+++ b/op-e2e/actions/span_batch_test.go
@@ -105,7 +105,12 @@ func TestDropSpanBatchBeforeHardfork(gt *testing.T) {
 		require.NoError(t, err)
 		// because verifier drops every span batch, it should generate empty blocks.
 		// so every block has only L1 attribute deposit transaction.
-		require.Equal(t, block.Transactions().Len(), 1)
+		// if Kroma Burgundy enabled, every block has L1 attr tx and mint token tx.
+		if sd.RollupCfg.BurgundyTime != nil && block.Time() > *sd.RollupCfg.BurgundyTime {
+			require.Equal(t, block.Transactions().Len(), 2)
+		} else {
+			require.Equal(t, block.Transactions().Len(), 1)
+		}
 	}
 	// check that the tx from alice is not included in verifier's chain
 	_, _, err = verifCl.TransactionByHash(t.Ctx(), tx.Hash())
@@ -212,7 +217,12 @@ func TestHardforkMiddleOfSpanBatch(gt *testing.T) {
 		require.NoError(t, err)
 		// Because verifier drops every span batch, it should generate empty blocks.
 		// So every block has only L1 attribute deposit transaction.
-		require.Equal(t, block.Transactions().Len(), 1)
+		// if Kroma Burgundy enabled, every block has L1 attr tx and mint token tx.
+		if sd.RollupCfg.BurgundyTime != nil && block.Time() > *sd.RollupCfg.BurgundyTime {
+			require.Equal(t, block.Transactions().Len(), 2)
+		} else {
+			require.Equal(t, block.Transactions().Len(), 1)
+		}
 	}
 	// Check that the tx from alice is not included in verifier's chain
 	_, _, err = verifCl.TransactionByHash(t.Ctx(), tx.Hash())

--- a/op-e2e/mint_token_test.go
+++ b/op-e2e/mint_token_test.go
@@ -1,0 +1,254 @@
+package op_e2e
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kroma-network/kroma/kroma-bindings/bindings"
+	"github.com/kroma-network/kroma/kroma-bindings/predeploys"
+	"github.com/kroma-network/kroma/op-e2e/e2eutils/geth"
+	"github.com/kroma-network/kroma/op-e2e/e2eutils/wait"
+)
+
+var (
+	floorUnit = big.NewInt(1e18 / 1e8)
+	zeroTime  = hexutil.Uint64(0)
+)
+
+func TestMintToken(t *testing.T) {
+	InitParallel(t)
+
+	t.Run("MintAndDistribute", func(t *testing.T) {
+		cfg := DefaultSystemConfig(t)
+
+		cfg.DeployConfig.L2GenesisBurgundyTimeOffset = &zeroTime
+		cfg.DeployConfig.MintManagerSlidingWindowBlocks = 5
+
+		sys, err := cfg.Start(t)
+		require.Nil(t, err, "Error starting up system")
+		defer sys.Close()
+
+		l2Client := sys.Clients["sequencer"]
+
+		governanceToken, err := bindings.NewGovernanceTokenCaller(predeploys.GovernanceTokenAddr, l2Client)
+		require.NoError(t, err)
+
+		// Ensure tokens are minted and distributed correctly until the epoch 5 ended
+		for i := uint64(1); i <= 5; i++ {
+			blockNumber := new(big.Int).SetUint64(cfg.DeployConfig.MintManagerSlidingWindowBlocks * i)
+			block, err := geth.WaitForBlock(blockNumber, l2Client, 10*time.Second)
+			require.NoError(t, err)
+			checkBalance(t, cfg, governanceToken, block.Number())
+		}
+	})
+
+	t.Run("InitMintPerBlock_100", func(t *testing.T) {
+		cfg := DefaultSystemConfig(t)
+
+		initMintPerBlock := hexutil.Big(*new(big.Int).Mul(big.NewInt(100), big.NewInt(1e18)))
+		cfg.DeployConfig.L2GenesisBurgundyTimeOffset = &zeroTime
+		cfg.DeployConfig.MintManagerInitMintPerBlock = &initMintPerBlock
+		cfg.DeployConfig.MintManagerSlidingWindowBlocks = 5
+
+		sys, err := cfg.Start(t)
+		require.Nil(t, err, "Error starting up system")
+		defer sys.Close()
+
+		l2Client := sys.Clients["sequencer"]
+
+		governanceToken, err := bindings.NewGovernanceTokenCaller(predeploys.GovernanceTokenAddr, l2Client)
+		require.NoError(t, err)
+
+		prevSupply := big.NewInt(0)
+
+		for i := uint64(1); i <= cfg.DeployConfig.MintManagerSlidingWindowBlocks; i++ {
+			blockNumber := new(big.Int).SetUint64(i)
+			_, err := geth.WaitForBlock(blockNumber, l2Client, 2*time.Second)
+			currentSupply, err := governanceToken.TotalSupply(&bind.CallOpts{BlockNumber: blockNumber})
+			require.NoError(t, err)
+			mintAmount := new(big.Int).Sub(currentSupply, prevSupply)
+			require.Equal(t, mintAmount, cfg.DeployConfig.MintManagerInitMintPerBlock.ToInt())
+			prevSupply = currentSupply
+		}
+	})
+
+	t.Run("Decayed", func(t *testing.T) {
+		cfg := DefaultSystemConfig(t)
+
+		cfg.DeployConfig.L2GenesisBurgundyTimeOffset = &zeroTime
+		cfg.DeployConfig.MintManagerSlidingWindowBlocks = 1
+
+		sys, err := cfg.Start(t)
+		require.Nil(t, err, "Error starting up system")
+		defer sys.Close()
+
+		l2Client := sys.Clients["sequencer"]
+
+		governanceToken, err := bindings.NewGovernanceToken(predeploys.GovernanceTokenAddr, l2Client)
+		require.NoError(t, err)
+		prevMint := new(big.Int).Set(cfg.DeployConfig.MintManagerInitMintPerBlock.ToInt())
+		prevSupply, err := governanceToken.TotalSupply(&bind.CallOpts{})
+		require.NoError(t, err)
+
+		// Ensure that the number of tokens minted in each block decreases for about 10 blocks.
+		for i := int64(1); i <= 10; i++ {
+			_, err := geth.WaitForBlock(big.NewInt(i), l2Client, 2*time.Second)
+			require.NoError(t, err)
+			currentSupply, err := governanceToken.TotalSupply(&bind.CallOpts{})
+			require.NoError(t, err)
+			require.Equal(t, currentSupply.Cmp(prevSupply), 1)
+			currentMint := new(big.Int).Sub(currentSupply, prevSupply)
+			require.Equal(t, currentMint.Cmp(prevMint), -1)
+
+			prevSupply = currentSupply
+			prevMint = currentMint
+		}
+	})
+
+	t.Run("Exhausted", func(t *testing.T) {
+		cfg := DefaultSystemConfig(t)
+
+		cfg.DeployConfig.L2GenesisBurgundyTimeOffset = &zeroTime
+		cfg.DeployConfig.MintManagerSlidingWindowBlocks = 1
+
+		sys, err := cfg.Start(t)
+		require.Nil(t, err, "Error starting up system")
+		defer sys.Close()
+
+		l2Client := sys.Clients["sequencer"]
+
+		governanceToken, err := bindings.NewGovernanceToken(predeploys.GovernanceTokenAddr, l2Client)
+		require.NoError(t, err)
+		mintManager, err := bindings.NewMintManagerCaller(predeploys.MintManagerAddr, l2Client)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
+		epochBlocks := new(big.Int).SetUint64(cfg.DeployConfig.MintManagerSlidingWindowBlocks)
+		prevSupply := big.NewInt(0)
+		blockNum := big.NewInt(1)
+		for {
+			select {
+			case <-ctx.Done():
+				require.Fail(t, "token not exhausted", ctx.Err())
+				break
+			default:
+				err := wait.ForNextBlock(ctx, l2Client)
+				require.NoError(t, err)
+				currentSupply, err := governanceToken.TotalSupply(&bind.CallOpts{})
+				require.NoError(t, err)
+
+				if currentSupply.Cmp(prevSupply) == 0 {
+					mintAmount, err := mintManager.MintAmountPerBlock(&bind.CallOpts{}, blockNum)
+					require.NoError(t, err)
+					if mintAmount.Uint64() == 0 {
+						return
+					}
+				}
+
+				prevSupply = currentSupply
+				blockNum.Add(blockNum, epochBlocks)
+			}
+		}
+	})
+}
+
+func TestInitialMint(t *testing.T) {
+	cfg := DefaultSystemConfig(t)
+
+	burgundyBlock := uint64(5)
+	burgundyTimeOffset := hexutil.Uint64(burgundyBlock * cfg.DeployConfig.L2BlockTime)
+	cfg.DeployConfig.L2GenesisBurgundyTimeOffset = &burgundyTimeOffset
+	cfg.DeployConfig.MintManagerSlidingWindowBlocks = 1
+
+	sys, err := cfg.Start(t)
+	require.Nil(t, err, "Error starting up system")
+	defer sys.Close()
+
+	l2Client := sys.Clients["sequencer"]
+
+	governanceToken, err := bindings.NewGovernanceTokenCaller(predeploys.GovernanceTokenAddr, l2Client)
+	require.NoError(t, err)
+
+	targetBlockNum := new(big.Int).SetUint64(1)
+	block, err := geth.WaitForBlock(targetBlockNum, l2Client, 20*time.Second)
+	require.NoError(t, err)
+	supply, err := governanceToken.TotalSupply(&bind.CallOpts{BlockNumber: targetBlockNum})
+	require.NoError(t, err)
+	require.Equal(t, supply.Uint64(), uint64(0))
+
+	targetBlockNum = new(big.Int).SetUint64(burgundyBlock)
+	block, err = geth.WaitForBlock(targetBlockNum, l2Client, 20*time.Second)
+	require.NoError(t, err)
+	checkBalance(t, cfg, governanceToken, block.Number())
+}
+
+func checkBalance(t *testing.T, cfg SystemConfig, token *bindings.GovernanceTokenCaller, blockNumber *big.Int) {
+	callOpts := &bind.CallOpts{BlockNumber: blockNumber}
+
+	expected := estimateTotalSupply(cfg, blockNumber)
+	totalSupply, err := token.TotalSupply(callOpts)
+	require.NoError(t, err)
+	require.Equal(t, expected, totalSupply)
+
+	for i, acc := range cfg.DeployConfig.MintManagerRecipients {
+		expected := new(big.Int).SetUint64(cfg.DeployConfig.MintManagerShares[i])
+		expected.Mul(expected, totalSupply)
+		expected.Div(expected, big.NewInt(1e5))
+		balance, err := token.BalanceOf(callOpts, acc)
+		require.NoError(t, err)
+		require.Equal(t, expected, balance)
+	}
+}
+
+func epochAndOffset(cfg SystemConfig, blockNumber *big.Int) (uint64, uint64) {
+	epoch := blockNumber.Uint64()/cfg.DeployConfig.MintManagerSlidingWindowBlocks + 1
+	offset := blockNumber.Uint64() % cfg.DeployConfig.MintManagerSlidingWindowBlocks
+	if offset == 0 {
+		epoch = epoch - 1
+		offset = cfg.DeployConfig.MintManagerSlidingWindowBlocks
+	}
+
+	return epoch, offset
+}
+
+func mintAmountPerBlock(cfg SystemConfig, epoch uint64) *big.Int {
+	decayingFactor := new(big.Int).SetUint64(cfg.DeployConfig.MintManagerDecayingFactor)
+	decayingDenom := new(big.Int).SetUint64(1e5)
+
+	amount := new(big.Int).Set(cfg.DeployConfig.MintManagerInitMintPerBlock.ToInt())
+	for i := uint64(1); i < epoch; i++ {
+		amount.Mul(amount, decayingFactor).Div(amount, decayingDenom)
+		amount.Div(amount, floorUnit).Mul(amount, floorUnit)
+	}
+
+	return amount
+}
+
+func estimateTotalSupply(cfg SystemConfig, blockNumber *big.Int) *big.Int {
+	lastEpoch, offset := epochAndOffset(cfg, blockNumber)
+
+	totalSupply := big.NewInt(0)
+	for epoch := uint64(1); epoch < lastEpoch; epoch++ {
+		mintPerBlock := mintAmountPerBlock(cfg, epoch)
+		blocks := new(big.Int).SetUint64(cfg.DeployConfig.MintManagerSlidingWindowBlocks)
+		amount := new(big.Int).Mul(mintPerBlock, blocks)
+		totalSupply.Add(totalSupply, amount)
+	}
+
+	if offset > 0 {
+		mintPerBlock := mintAmountPerBlock(cfg, lastEpoch)
+		blocks := new(big.Int).SetUint64(offset)
+		amount := new(big.Int).Mul(mintPerBlock, blocks)
+		totalSupply.Add(totalSupply, amount)
+	}
+
+	return totalSupply
+}

--- a/op-e2e/op_geth.go
+++ b/op-e2e/op_geth.go
@@ -8,6 +8,15 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	gn "github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
@@ -17,14 +26,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/log"
-	gn "github.com/ethereum/go-ethereum/node"
-	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/stretchr/testify/require"
 	"github.com/kroma-network/kroma/kroma-chain-ops/genesis"
 )
 
@@ -208,6 +209,15 @@ func (d *OpGeth) CreatePayloadAttributes(txs ...*types.Transaction) (*eth.Payloa
 
 	var txBytes []hexutil.Bytes
 	txBytes = append(txBytes, l1Info)
+	// [Kroma: START]
+	burgundy := d.L2ChainConfig.IsBurgundy(uint64(timestamp))
+	if burgundy {
+		mintToken, err := derive.MintTokenTxBytes(uint64(d.L2Head.BlockNumber) + 1)
+		if err != nil {
+			return nil, err
+		}
+		txBytes = append(txBytes, mintToken)
+	}
 	for _, tx := range txs {
 		bin, err := tx.MarshalBinary()
 		if err != nil {

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -99,6 +99,9 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 	deployConfig.L1GenesisBlockTimestamp = hexutil.Uint64(time.Now().Unix())
 	deployConfig.L2GenesisCanyonTimeOffset = e2eutils.CanyonTimeOffset()
 	// [Kroma: START]
+	// If you want to test for the Burgundy hardfork, set the value directly in that test.
+	// Burgundy hardfork should be disabled by default to prevent Optimism tests from failing.
+	deployConfig.L2GenesisBurgundyTimeOffset = nil
 	deployConfig.ValidatorPoolRoundDuration = deployConfig.L2OutputOracleSubmissionInterval * deployConfig.L2BlockTime / 2
 	// [Kroma: END]
 	require.NoError(t, deployConfig.Check(), "Deploy config is invalid, do you need to run make devnet-allocs?")

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -106,6 +106,14 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 
 	txs := make([]hexutil.Bytes, 0, 1+len(depositTxs))
 	txs = append(txs, l1InfoTx)
+	if ba.cfg.IsBurgundy(nextL2Time) {
+		mintTokenTx, err := MintTokenTxBytes(l2Parent.Number + 1)
+		if err != nil {
+			return nil, NewCriticalError(fmt.Errorf("failed to create mintTokenTx: %w", err))
+		}
+
+		txs = append(txs, mintTokenTx)
+	}
 	txs = append(txs, depositTxs...)
 
 	var withdrawals *types.Withdrawals

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type BatchWithL1InclusionBlock struct {
@@ -32,7 +33,8 @@ const (
 // The first entry of the l1Blocks should match the origin of the l2SafeHead. One or more consecutive l1Blocks should be provided.
 // In case of only a single L1 block, the decision whether a batch is valid may have to stay undecided.
 func CheckBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef,
-	l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock, l2Fetcher SafeBlockFetcher) BatchValidity {
+	l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock, l2Fetcher SafeBlockFetcher,
+) BatchValidity {
 	switch batch.Batch.GetBatchType() {
 	case SingularBatchType:
 		singularBatch, ok := batch.Batch.(*SingularBatch)
@@ -166,7 +168,8 @@ func checkSingularBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1Blo
 
 // checkSpanBatch implements SpanBatch validation rule.
 func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
-	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher) BatchValidity {
+	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher,
+) BatchValidity {
 	// add details to the log
 	log = batch.LogContext(log)
 
@@ -282,7 +285,6 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 				originIdx = j
 				break
 			}
-
 		}
 		if i > 0 {
 			originAdvanced = false
@@ -349,7 +351,7 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 			// execution payload has deposit TXs, but batch does not.
 			depositCount := 0
 			for _, tx := range safeBlockTxs {
-				if tx[0] == types.DepositTxType {
+				if tx[0] == types.DepositTxType || tx[0] == types.MintTokenTxType {
 					depositCount++
 				}
 			}

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -7,15 +7,18 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
-var ErrMaxFrameSizeTooSmall = errors.New("maxSize is too small to fit the fixed frame overhead")
-var ErrNotDepositTx = errors.New("first transaction in block is not a deposit tx")
-var ErrTooManyRLPBytes = errors.New("batch would cause RLP bytes to go over limit")
+var (
+	ErrMaxFrameSizeTooSmall = errors.New("maxSize is too small to fit the fixed frame overhead")
+	ErrNotDepositTx         = errors.New("first transaction in block is not a deposit tx")
+	ErrTooManyRLPBytes      = errors.New("batch would cause RLP bytes to go over limit")
+)
 
 // FrameV0OverHeadSize is the absolute minimum size of a frame.
 // This is the fixed overhead frame size, calculated as specified
@@ -225,7 +228,7 @@ func (co *SingularChannelOut) OutputFrame(w *bytes.Buffer, maxSize uint64) (uint
 func BlockToSingularBatch(block *types.Block) (*SingularBatch, L1BlockInfo, error) {
 	opaqueTxs := make([]hexutil.Bytes, 0, len(block.Transactions()))
 	for i, tx := range block.Transactions() {
-		if tx.Type() == types.DepositTxType {
+		if tx.Type() == types.DepositTxType || tx.Type() == types.MintTokenTxType {
 			continue
 		}
 		otx, err := tx.MarshalBinary()

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -985,6 +985,16 @@ func TestBlockBuildingRace(t *testing.T) {
 			a1InfoTx,
 		},
 	}
+
+	// [Kroma: START]
+	if cfg.BurgundyTime != nil && refA1.Time >= *cfg.BurgundyTime {
+		a1MintTx, err := MintTokenTxBytes(refA1.Number)
+		require.NoError(t, err)
+
+		payloadA1.Transactions = append(payloadA1.Transactions, a1MintTx)
+	}
+	// [Kroma: END]
+
 	eng.ExpectGetPayload(id, payloadA1, nil)
 	eng.ExpectNewPayload(payloadA1, &eth.PayloadStatusV1{
 		Status:          eth.ExecutionValid,

--- a/op-node/rollup/derive/engine_update.go
+++ b/op-node/rollup/derive/engine_update.go
@@ -20,6 +20,15 @@ func isDepositTx(opaqueTx eth.Data) (bool, error) {
 	return opaqueTx[0] == types.DepositTxType, nil
 }
 
+// isMintTokenTx checks an opaqueTx to determine if it is a Mint Token Transaction
+// It has to return an error in the case the transaction is empty
+func isMintTokenTx(opaqueTx eth.Data) (bool, error) {
+	if len(opaqueTx) == 0 {
+		return false, errors.New("empty transaction")
+	}
+	return opaqueTx[0] == types.MintTokenTxType, nil
+}
+
 // lastDeposit finds the index of last deposit at the start of the transactions.
 // It walks the transactions from the start until it finds a non-deposit tx.
 // An error is returned if any looked at transaction cannot be decoded
@@ -30,6 +39,15 @@ func lastDeposit(txns []eth.Data) (int, error) {
 		if err != nil {
 			return 0, fmt.Errorf("invalid transaction at idx %d", i)
 		}
+		// [Kroma: START]
+		mintToken, err := isMintTokenTx(tx)
+		if err != nil {
+			return 0, fmt.Errorf("invalid transaction at idx %d", i)
+		}
+		if mintToken {
+			continue
+		}
+		// [Kroma: END]
 		if deposit {
 			lastDeposit = i
 		} else {

--- a/op-node/rollup/derive/mint_token.go
+++ b/op-node/rollup/derive/mint_token.go
@@ -1,0 +1,87 @@
+package derive
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/ethereum-optimism/optimism/op-service/solabi"
+	"github.com/kroma-network/kroma/kroma-bindings/predeploys"
+)
+
+const (
+	MintTokenFuncSignature = "mint()"
+	MintTokenLen           = 4
+)
+
+var (
+	MintTokenFuncBytes4    = crypto.Keccak256([]byte(MintTokenFuncSignature))[:4]
+	MintTokenCallerAddress = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0070")
+	MintManagerAddress     = predeploys.MintManagerAddr
+)
+
+const (
+	MintTokenTxGas = 1_000_000
+)
+
+type MintToken struct{}
+
+// Binary Format
+// +---------+--------------------------+
+// | Bytes   | Field                    |
+// +---------+--------------------------+
+// | 4       | Function signature       |
+// +---------+--------------------------+
+
+func (info *MintToken) MarshalBinary() ([]byte, error) {
+	w := bytes.NewBuffer(make([]byte, 0, MintTokenLen))
+	if err := solabi.WriteSignature(w, MintTokenFuncBytes4); err != nil {
+		return nil, err
+	}
+	return w.Bytes(), nil
+}
+
+func (info *MintToken) UnmarshalBinary(data []byte) error {
+	if len(data) != MintTokenLen {
+		return fmt.Errorf("data is unexpected length: %d", len(data))
+	}
+	reader := bytes.NewReader(data)
+
+	if _, err := solabi.ReadAndValidateSignature(reader, MintTokenFuncBytes4); err != nil {
+		return err
+	}
+	if !solabi.EmptyReader(reader) {
+		return errors.New("too many bytes")
+	}
+	return nil
+}
+
+// NewMintTokenTx creates a mint token transaction.
+func NewMintTokenTx(nonce uint64) (*types.MintTokenTx, error) {
+	out := &types.MintTokenTx{
+		From:  MintTokenCallerAddress,
+		To:    &MintManagerAddress,
+		Gas:   MintTokenTxGas,
+		Nonce: nonce,
+		Data:  MintTokenFuncBytes4,
+	}
+	return out, nil
+}
+
+// MintTokenTxBytes returns a serialized mint token transaction.
+func MintTokenTxBytes(nextBlockNumber uint64) ([]byte, error) {
+	mintTokenTx, err := NewMintTokenTx(nextBlockNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mint token tx: %w", err)
+	}
+	tx := types.NewTx(mintTokenTx)
+	opaqueTx, err := tx.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode mint token tx: %w", err)
+	}
+	return opaqueTx, nil
+}

--- a/packages/contracts/src/constants.ts
+++ b/packages/contracts/src/constants.ts
@@ -1,4 +1,4 @@
-import {ethers} from "ethers";
+import {ethers} from 'ethers'
 
 /**
  * Predeploys are Solidity contracts that are injected into the initial L2 state and provide
@@ -31,4 +31,5 @@ export const defaultResourceConfig = {
   minimumBaseFee: ethers.utils.parseUnits('1', 'gwei'),
   systemTxMaxGas: 1_000_000,
   maximumBaseFee: uint128Max,
+  mintTokenTxMaxGas: 1_000_000,
 }


### PR DESCRIPTION
Implement a transaction that mint tokens every block and add it to the payload attribute.
This PR should be merged after #269.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced functionality for interacting with and deploying the `MintManager` Ethereum smart contract, including minting tokens and handling events.
    - Added new configurations and functionalities in preparation for the Kroma Burgundy network upgrade, including handling of mint transactions and Burgundy time-based activations.
    - Implemented governance token functionality with new minting and burning capabilities, alongside adjustments to contract inheritance and internal logic.
    - Expanded testing capabilities with new test functions and scenarios for minting tokens and governance token operations.
    - Updated deployment scripts and contract artifacts for new and modified contracts, including `GovernanceToken` and `MintManager`.

- **Bug Fixes**
    - Adjusted file permissions and import orders in various test and utility files for consistency and compliance with best practices.

- **Documentation**
    - Added comments and updated documentation regarding Burgundy hardfork settings and test configurations.

- **Refactor**
    - Updated contract inheritance and internal functions for `GovernanceToken`.
    - Refactored code and logic related to transaction handling and batch processing in light of the Burgundy upgrade.

- **Tests**
    - Enhanced end-to-end testing with new scenarios for token minting, governance token functionality, and Burgundy feature activation.

- **Chores**
    - Updated storage layouts and gas snapshots for contracts, reflecting new functionalities and optimizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->