### PR TITLE
feat(validator): remove the limit of validator subcommand amount flag

### DIFF
--- a/kroma-validator/cmd/main.go
+++ b/kroma-validator/cmd/main.go
@@ -34,7 +34,7 @@ func main() {
 			Name:  "deposit",
 			Usage: "Deposit ETH into ValidatorPool to be used as bond",
 			Flags: []cli.Flag{
-				&cli.Uint64Flag{
+				&cli.StringFlag{
 					Name:     "amount",
 					Usage:    "Amount to deposit into ValidatorPool (in wei)",
 					Required: true,
@@ -46,7 +46,7 @@ func main() {
 			Name:  "withdraw",
 			Usage: "Withdraw ETH from ValidatorPool",
 			Flags: []cli.Flag{
-				&cli.Uint64Flag{
+				&cli.StringFlag{
 					Name:     "amount",
 					Usage:    "Amount to withdraw from ValidatorPool (in wei)",
 					Required: true,


### PR DESCRIPTION
# Description

Since the validator subcommand amount flag had a type of uint64, the flag was limited to a maximum value of about 18 ETH. By changing the type of the amount flag to string, it is possible to use unlimited values for the flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the handling of transaction amounts in the `deposit` and `withdraw` commands to accept string inputs, allowing for more flexible and precise transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->