### PR TITLE
chore: set Ecotone time for Kroma mainnet

### DIFF
--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -41,7 +41,7 @@ var Mainnet = &rollup.Config{
 	RegolithTime:           u64Ptr(0),
 	CanyonTime:             u64Ptr(1708502400),
 	DeltaTime:              u64Ptr(1709107200),
-	EcotoneTime:            nil,
+	EcotoneTime:            u64Ptr(1713772800),
 	FjordTime:              nil,
 	InteropTime:            nil,
 	/* [Kroma: START]

--- a/op-node/chaincfg/chains_test.go
+++ b/op-node/chaincfg/chains_test.go
@@ -68,7 +68,7 @@ var mainnetCfg = rollup.Config{
 	RegolithTime:           u64Ptr(0),
 	CanyonTime:             u64Ptr(1708502400),
 	DeltaTime:              u64Ptr(1709107200),
-	EcotoneTime:            nil,
+	EcotoneTime:            u64Ptr(1713772800),
 	FjordTime:              nil,
 	InteropTime:            nil,
 	/* [Kroma: START]

--- a/ops-devnet/docker-compose.yml
+++ b/ops-devnet/docker-compose.yml
@@ -107,7 +107,7 @@ services:
 
   l2:
     pid: host # allow debugging
-    image: kromanetwork/geth:v0.5.0-rc.4
+    image: kromanetwork/geth:v0.5.0
     ports:
       - "9545:8545"
       - "9546:8546"


### PR DESCRIPTION
Set Ecotone activation time for Kroma mainnet.
The activation time is Mon `Apr 22 2024 08:00:00`(unix timestamp `1713772800`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Mainnet configuration with a new EcotoneTime value to enhance network synchronization.

- **Bug Fixes**
	- Upgraded Docker image for improved stability and performance in the l2 service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->