### PR TITLE
chore: change Ecotone time for Kroma mainnet

### DIFF
--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -41,7 +41,7 @@ var Mainnet = &rollup.Config{
 	RegolithTime:           u64Ptr(0),
 	CanyonTime:             u64Ptr(1708502400),
 	DeltaTime:              u64Ptr(1709107200),
-	EcotoneTime:            u64Ptr(1713772800),
+	EcotoneTime:            u64Ptr(1713772801),
 	FjordTime:              nil,
 	InteropTime:            nil,
 	/* [Kroma: START]

--- a/op-node/chaincfg/chains_test.go
+++ b/op-node/chaincfg/chains_test.go
@@ -68,7 +68,7 @@ var mainnetCfg = rollup.Config{
 	RegolithTime:           u64Ptr(0),
 	CanyonTime:             u64Ptr(1708502400),
 	DeltaTime:              u64Ptr(1709107200),
-	EcotoneTime:            u64Ptr(1713772800),
+	EcotoneTime:            u64Ptr(1713772801),
 	FjordTime:              nil,
 	InteropTime:            nil,
 	/* [Kroma: START]


### PR DESCRIPTION
The timestamp for Kroma mainnet should be odd number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the `EcotoneTime` value in the Mainnet configuration to ensure accurate timing for rollup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->