### PR TITLE
chore: change Ecotone time for Kroma mainnet

### DIFF
--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -41,7 +41,7 @@ var Mainnet = &rollup.Config{
 	RegolithTime:           u64Ptr(0),
 	CanyonTime:             u64Ptr(1708502400),
 	DeltaTime:              u64Ptr(1709107200),
-	EcotoneTime:            u64Ptr(1713772801),
+	EcotoneTime:            u64Ptr(1714032001),
 	FjordTime:              nil,
 	InteropTime:            nil,
 	/* [Kroma: START]

--- a/op-node/chaincfg/chains_test.go
+++ b/op-node/chaincfg/chains_test.go
@@ -68,7 +68,7 @@ var mainnetCfg = rollup.Config{
 	RegolithTime:           u64Ptr(0),
 	CanyonTime:             u64Ptr(1708502400),
 	DeltaTime:              u64Ptr(1709107200),
-	EcotoneTime:            u64Ptr(1713772801),
+	EcotoneTime:            u64Ptr(1714032001),
 	FjordTime:              nil,
 	InteropTime:            nil,
 	/* [Kroma: START]


### PR DESCRIPTION
Change Ecotone activation time for Kroma mainnet.
The activation time is `Thu Apr 25 2024 08:00:01`(unix timestamp `1714032001`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the EcotoneTime setting for the Mainnet configuration to ensure accurate timing alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->