### PR TITLE
docs: fix invalid spec links

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,6 @@ e2e
 
 node_modules
 packages/
-specs/
 test
 tests/testdata
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,15 @@
 # Components
+
 /components @kroma-network/l2-protocol
 /e2e        @kroma-network/l2-protocol
 /utils      @kroma-network/l2-protocol
 
 # Contracts
+
 /bindings @kroma-network/l2-protocol
 /packages @kroma-network/l2-protocol
 
 # Ops
+
 /.github    @kroma-network/devops
 /ops-devnet @kroma-network/devops
-
-# Misc
-/specs @kroma-network/l2-protocol

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ There are plenty of ways to contribute, in particular we appreciate support in t
   which are meant as introductory issues for external contributors.
 - Join [Kroma Discord](https://discord.gg/kroma) and answer the questions.
 - Get involved in the protocol design process by proposing changes or new features or write parts of the spec yourself
-  in the [specs](./specs).
+  in the [specs](https://specs.kroma.network).
 
 Note that we have a [Code of Conduct](https://github.com/kroma-network/.github/blob/main/CODE_OF_CONDUCT.md),
 please follow it in all your interactions with the project.
@@ -74,16 +74,16 @@ and how you should use it to maintain a clean commit history.
 
 You'll need the following:
 
-* [Git](https://git-scm.com/downloads)
-* [NodeJS](https://nodejs.org/en/download/)
-* [Node Version Manager](https://github.com/nvm-sh/nvm)
-* [pnpm](https://pnpm.io/installation)
-* [Docker](https://docs.docker.com/get-docker/)
-* [Docker Compose](https://docs.docker.com/compose/install/)
-* [Go](https://go.dev/dl/)
-* [Foundry](https://getfoundry.sh)
-* [jq](https://jqlang.github.io/jq/)
-* [go-ethereum](https://github.com/ethereum/go-ethereum)
+- [Git](https://git-scm.com/downloads)
+- [NodeJS](https://nodejs.org/en/download/)
+- [Node Version Manager](https://github.com/nvm-sh/nvm)
+- [pnpm](https://pnpm.io/installation)
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+- [Go](https://go.dev/dl/)
+- [Foundry](https://getfoundry.sh)
+- [jq](https://jqlang.github.io/jq/)
+- [go-ethereum](https://github.com/ethereum/go-ethereum)
 
 ### Setup
 
@@ -148,9 +148,11 @@ pnpm test
 #### Running unit tests (Go)
 
 Change directory to the package you want to run tests for. Then:
+
 ```shell
 go test ./...
 ```
 
 #### Running e2e tests (Go)
+
 See [this document](./op-e2e/README.md)

--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ Additionally, Kroma is advancing towards decentralization. As an initial step fo
 permissionless validator and challenge system.
 
 For more detailed information about Kroma, check [Kroma docs](https://docs.kroma.network) (or
-[spec docs](./specs)).
+[spec docs](https://specs.kroma.network)).
 
 ## Links
 
 - Official Website: [Kroma](https://kroma.network)
 - Documentation: [Kroma Docs](https://docs.kroma.network)
+- Specs: [Kroma Specs](https://specs.kroma.network)
 - Blog: [Kroma Medium](https://medium.com/@kroma-network)
 - Discord: [Kroma Discord](https://discord.gg/kroma)
 - X (Twitter): [Kroma X](https://twitter.com/kroma_network)

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,39 +1,39 @@
 # Kroma Smart Contracts
 
 This package contains the smart contracts that compose the on-chain component of Kroma.
-You can find detailed specifications for the contracts contained within this package [here](../../specs).
+You can find detailed specifications for the contracts contained within this package [here](https://specs.kroma.network).
 
 ## Contracts Overview
 
 ### Contracts deployed to L1
 
-| Name                                                                                             | Proxy Type                                 | Description |
-|--------------------------------------------------------------------------------------------------|--------------------------------------------|-------------|
-| [`L1CrossDomainMessenger`](../../specs/messengers.md)                                            | [`Proxy`](./contracts/universal/Proxy.sol) |             |
-| High-level interface for sending messages to and receiving messages from Kroma                   |                                            |             |
-| [`L1StandardBridge`](../../specs/bridges.md)                                                     | [`Proxy`](./contracts/universal/Proxy.sol) |             |
-| Standardized system for transfering ERC20 tokens to/from Kroma                                   |                                            |             |
-| [`L2OutputOracle`](../../specs/validator.md#l2-output-oracle-smart-contract)                     | [`Proxy`](./contracts/universal/Proxy.sol) |             |
-| Stores commitments to the state of Kroma which can be used by contracts on L1 to access L2 state |                                            |             |
-| [`KromaPortal`](../../specs/deposits.md#deposit-contract)                                        | [`Proxy`](./contracts/universal/Proxy.sol) |             |
-| Low-level message passing interface                                                              |                                            |             |
-| [`KromaMintableERC20Factory`](../../specs/predeploys.md#KromaMintableerc20factory)               | [`Proxy`](./contracts/universal/Proxy.sol) |             |
-| Deploys standard `KromaMintableERC20` tokens that are compatible with either `StandardBridge`    |                                            |             |
-| [`ProxyAdmin`](../../specs/TODO)                                                                 | -                                          |             |
-| Contract that can upgrade L1 contracts                                                           |                                            |             |
+| Name                                                                                                          | Proxy Type                                 | Description |
+|---------------------------------------------------------------------------------------------------------------|--------------------------------------------|-------------|
+| [`L1CrossDomainMessenger`](https://specs.kroma.network/protocol/messengers.html)                              | [`Proxy`](./contracts/universal/Proxy.sol) |             |
+| High-level interface for sending messages to and receiving messages from Kroma                                |                                            |             |
+| [`L1StandardBridge`](https://specs.kroma.network/protocol/bridges.html)                                       | [`Proxy`](./contracts/universal/Proxy.sol) |             |
+| Standardized system for transfering ERC20 tokens to/from Kroma                                                |                                            |             |
+| [`L2OutputOracle`](https://specs.kroma.network/protocol/validator.html#l2-output-oracle-smart-contract)       | [`Proxy`](./contracts/universal/Proxy.sol) |             |
+| Stores commitments to the state of Kroma which can be used by contracts on L1 to access L2 state              |                                            |             |
+| [`KromaPortal`](https://specs.kroma.network/protocol/deposits.html#deposit-contract)                          | [`Proxy`](./contracts/universal/Proxy.sol) |             |
+| Low-level message passing interface                                                                           |                                            |             |
+| [`KromaMintableERC20Factory`](https://specs.kroma.network/protocol/predeploys.html#kromamintableerc20factory) | [`Proxy`](./contracts/universal/Proxy.sol) |             |
+| Deploys standard `KromaMintableERC20` tokens that are compatible with either `StandardBridge`                 |                                            |             |
+| [`ProxyAdmin`](https://specs.kroma.network/protocol/predeploys.html#proxyadmin)                               | -                                          |             |
+| Contract that can upgrade L1 contracts                                                                        |                                            |             |
 
 ### Contracts deployed to L2
 
-| Name                                                                               | Proxy Type                                 | Description                                                                                   |
-|------------------------------------------------------------------------------------|--------------------------------------------|-----------------------------------------------------------------------------------------------|
-| [`GasPriceOracle`](../../specs/predeploys.md#gaspriceoracle)                       | [`Proxy`](./contracts/universal/Proxy.sol) | Stores L2 gas price configuration values                                                      |
-| [`L1Block`](../../specs/predeploys.md#l1block)                                     | [`Proxy`](./contracts/universal/Proxy.sol) | Stores L1 block context information (e.g., latest known L1 block hash)                        |
-| [`L2CrossDomainMessenger`](../../specs/predeploys.md#l2crossdomainmessenger)       | [`Proxy`](./contracts/universal/Proxy.sol) | High-level interface for sending messages to and receiving messages from L1                   |
-| [`L2StandardBridge`](../../specs/predeploys.md#l2standardbridge)                   | [`Proxy`](./contracts/universal/Proxy.sol) | Standardized system for transferring ERC20 tokens to/from L1                                  |
-| [`L2ToL1MessagePasser`](../../specs/predeploys.md#l2tol1messagepasser)             | [`Proxy`](./contracts/universal/Proxy.sol) | Low-level message passing interface                                                           |
-| [`ValidatorRewardVault`](../../specs/predeploys.md#validatorrewardvault)           | [`Proxy`](./contracts/universal/Proxy.sol) | Vault for L2 transaction fees                                                                 |
-| [`KromaMintableERC20Factory`](../../specs/predeploys.md#KromaMintableerc20factory) | [`Proxy`](./contracts/universal/Proxy.sol) | Deploys standard `KromaMintableERC20` tokens that are compatible with either `StandardBridge` |
-| [`L2ProxyAdmin`](../../specs/TODO)                                                 | -                                          | Contract that can upgrade L2 contracts when sent a transaction from L1                        |
+| Name                                                                                                          | Proxy Type                                 | Description                                                                                   |
+|---------------------------------------------------------------------------------------------------------------|--------------------------------------------|-----------------------------------------------------------------------------------------------|
+| [`GasPriceOracle`](https://specs.kroma.network/protocol/predeploys.html#gaspriceoracle)                       | [`Proxy`](./contracts/universal/Proxy.sol) | Stores L2 gas price configuration values                                                      |
+| [`L1Block`](https://specs.kroma.network/protocol/predeploys.html#l1block)                                     | [`Proxy`](./contracts/universal/Proxy.sol) | Stores L1 block context information (e.g., latest known L1 block hash)                        |
+| [`L2CrossDomainMessenger`](https://specs.kroma.network/protocol/predeploys.html#l2crossdomainmessenger)       | [`Proxy`](./contracts/universal/Proxy.sol) | High-level interface for sending messages to and receiving messages from L1                   |
+| [`L2StandardBridge`](https://specs.kroma.network/protocol/predeploys.html#l2standardbridge)                   | [`Proxy`](./contracts/universal/Proxy.sol) | Standardized system for transferring ERC20 tokens to/from L1                                  |
+| [`L2ToL1MessagePasser`](https://specs.kroma.network/protocol/predeploys.html#l2tol1messagepasser)             | [`Proxy`](./contracts/universal/Proxy.sol) | Low-level message passing interface                                                           |
+| [`ValidatorRewardVault`](https://specs.kroma.network/protocol/predeploys.html#validatorrewardvault)           | [`Proxy`](./contracts/universal/Proxy.sol) | Vault for L2 transaction fees                                                                 |
+| [`KromaMintableERC20Factory`](https://specs.kroma.network/protocol/predeploys.html#kromamintableerc20factory) | [`Proxy`](./contracts/universal/Proxy.sol) | Deploys standard `KromaMintableERC20` tokens that are compatible with either `StandardBridge` |
+| [`L2ProxyAdmin`](https://specs.kroma.network/protocol/predeploys.html#proxyadmin)                             | -                                          | Contract that can upgrade L2 contracts when sent a transaction from L1                        |
 
 ## Installation
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -53,7 +53,7 @@ We work on this repository with a combination of [Hardhat](https://hardhat.org) 
    A specific version must be used.
 
    ```shell
-   > foundryup --version nightly-d369d2486f85576eec4ca41d277391dfdae21ba7
+   > foundryup --version nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9
    ```
 
 2. Install node modules with pnpm and Node.js:

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "abigen": "v1.13.14",
-  "foundry": "a170021b0e058925047a2c9697ba61f10fc0b2ce",
+  "foundry": "f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9",
   "geth": "v1.13.4",
   "nvm": "v20.9.0",
   "slither": "0.10.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated external links in `CONTRIBUTING.md` to absolute URLs for better accessibility and navigation.
	- Updated the specifications documentation link in the `README.md` and `packages/contracts/README.md` to point to the correct external URL.
- **Chores**
	- Modified `.dockerignore` to include the `specs/` directory.
	- Reorganized ownership assignments in the `.github/CODEOWNERS` file to better reflect current project structure and responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->