### PR TITLE
feat(contracts): unbond validator KRO

### DIFF
--- a/packages/contracts/contracts/L1/AssetManager.sol
+++ b/packages/contracts/contracts/L1/AssetManager.sol
@@ -690,17 +690,14 @@ contract AssetManager is ISemver, IERC721Receiver, IAssetManager {
      */
     function bondValidatorKro(address validator) external onlyValidatorManager {
         Asset storage asset = _vaults[validator].asset;
-        if (asset.validatorKro - asset.validatorKroBonded < BOND_AMOUNT) revert InsufficientAsset();
+        uint128 remainder = asset.validatorKro - asset.validatorKroBonded;
+        if (remainder < BOND_AMOUNT) revert InsufficientAsset();
 
         unchecked {
             asset.validatorKroBonded += BOND_AMOUNT;
         }
 
-        emit ValidatorKroBonded(
-            validator,
-            BOND_AMOUNT,
-            asset.validatorKro - asset.validatorKroBonded
-        );
+        emit ValidatorKroBonded(validator, BOND_AMOUNT, remainder - BOND_AMOUNT);
     }
 
     /**

--- a/packages/contracts/contracts/L1/AssetManager.sol
+++ b/packages/contracts/contracts/L1/AssetManager.sol
@@ -708,7 +708,16 @@ contract AssetManager is ISemver, IERC721Receiver, IAssetManager {
      */
     function unbondValidatorKro(address validator) external onlyValidatorManager {
         Asset storage asset = _vaults[validator].asset;
-        _unbondValidatorKro(validator, asset);
+
+        unchecked {
+            asset.validatorKroBonded -= BOND_AMOUNT;
+        }
+
+        emit ValidatorKroUnbonded(
+            validator,
+            BOND_AMOUNT,
+            asset.validatorKro - asset.validatorKroBonded
+        );
     }
 
     /**
@@ -737,9 +746,14 @@ contract AssetManager is ISemver, IERC721Receiver, IAssetManager {
             unchecked {
                 asset.totalKro += baseReward;
                 // TODO: handle reward for boosted reward
+                asset.validatorKroBonded -= BOND_AMOUNT;
             }
 
-            _unbondValidatorKro(validator, asset);
+            emit ValidatorKroUnbonded(
+                validator,
+                BOND_AMOUNT,
+                asset.validatorKro - asset.validatorKroBonded
+            );
         }
 
         // TODO - Distribute the reward from a designated vault to the AssetManager contract.
@@ -1173,25 +1187,6 @@ contract AssetManager is ISemver, IERC721Receiver, IAssetManager {
         kghDelegator.rewardPerKghPaid = rewardPerKghStored;
 
         return totalBoostedReward;
-    }
-
-    /**
-     * @notice Internal function to unbond KRO from validator KRO during output finalization or
-     *         challenge slashing.
-     *
-     * @param validator Address of the validator.
-     * @param asset     Asset information of the vault of the validator.
-     */
-    function _unbondValidatorKro(address validator, Asset storage asset) internal {
-        unchecked {
-            asset.validatorKroBonded -= BOND_AMOUNT;
-
-            emit ValidatorKroUnbonded(
-                validator,
-                BOND_AMOUNT,
-                asset.validatorKro - asset.validatorKroBonded
-            );
-        }
     }
 
     /**

--- a/packages/contracts/contracts/L1/AssetManager.sol
+++ b/packages/contracts/contracts/L1/AssetManager.sol
@@ -814,6 +814,27 @@ contract AssetManager is ISemver, IERC721Receiver, IAssetManager {
     }
 
     /**
+     * @notice Revert the changes of decreaseBalanceWithChallenge. This function is only called by
+     *         the ValidatorManager contract.
+     *
+     * @param loser Address of the challenge original loser.
+     *
+     * @return The challenge reward refunded to loser's asset.
+     */
+    function revertDecreaseBalanceWithChallenge(
+        address loser
+    ) external onlyValidatorManager returns (uint128) {
+        Asset storage asset = _vaults[loser].asset;
+
+        unchecked {
+            asset.validatorKroBonded += BOND_AMOUNT;
+            asset.validatorKro += BOND_AMOUNT;
+        }
+
+        return BOND_AMOUNT;
+    }
+
+    /**
      * @notice Add pending assets and shares when undelegating KRO.
      *
      * @param vault  Vault of the validator.

--- a/packages/contracts/contracts/L1/Colosseum.sol
+++ b/packages/contracts/contracts/L1/Colosseum.sol
@@ -707,8 +707,8 @@ contract Colosseum is Initializable, ISemver {
 
         // Switch validator system after validator pool contract terminated.
         if (L2_ORACLE.VALIDATOR_POOL().isTerminated(_outputIndex)) {
-            // Unjail asserter.
-            L2_ORACLE.VALIDATOR_MANAGER().tryUnjail(_asserter, true);
+            // Revert slash asserter.
+            L2_ORACLE.VALIDATOR_MANAGER().revertSlash(_outputIndex, _asserter);
             // Slash challenger.
             L2_ORACLE.VALIDATOR_MANAGER().slash(_outputIndex, _asserter, _challenger);
         }

--- a/packages/contracts/contracts/L1/Colosseum.sol
+++ b/packages/contracts/contracts/L1/Colosseum.sol
@@ -696,6 +696,8 @@ contract Colosseum is Initializable, ISemver {
         if (L2_ORACLE.VALIDATOR_POOL().isTerminated(_outputIndex)) {
             // Unjail asserter.
             L2_ORACLE.VALIDATOR_MANAGER().tryUnjail(_asserter, true);
+            // Slash challenger.
+            L2_ORACLE.VALIDATOR_MANAGER().slash(_outputIndex, _asserter, _challenger);
         }
 
         emit ChallengeDismissed(_outputIndex, _challenger, block.timestamp);
@@ -922,7 +924,9 @@ contract Colosseum is Initializable, ISemver {
         emit ChallengeCanceled(_outputIndex, msg.sender, block.timestamp);
 
         // Switch validator system after validator pool contract terminated.
-        if (!L2_ORACLE.VALIDATOR_POOL().isTerminated(_outputIndex)) {
+        if (L2_ORACLE.VALIDATOR_POOL().isTerminated(_outputIndex)) {
+            L2_ORACLE.VALIDATOR_MANAGER().unbondValidatorKro(msg.sender);
+        } else {
             L2_ORACLE.VALIDATOR_POOL().releasePendingBond(_outputIndex, msg.sender, msg.sender);
         }
 

--- a/packages/contracts/contracts/L1/ValidatorManager.sol
+++ b/packages/contracts/contracts/L1/ValidatorManager.sol
@@ -306,12 +306,15 @@ contract ValidatorManager is ISemver, IValidatorManager {
     /**
      * @inheritdoc IValidatorManager
      */
+    function unbondValidatorKro(address validator) external onlyColosseum {
+        ASSET_MANAGER.unbondValidatorKro(validator);
+    }
+
+    /**
+     * @inheritdoc IValidatorManager
+     */
     function slash(uint256 outputIndex, address winner, address loser) external onlyColosseum {
-        (uint128 tax, uint128 challengeReward) = ASSET_MANAGER.modifyBalanceWithChallenge(
-            loser,
-            0,
-            true
-        );
+        (uint128 tax, uint128 challengeReward) = ASSET_MANAGER.decreaseBalanceWithChallenge(loser);
 
         emit Slashed(outputIndex, loser, tax + challengeReward);
 
@@ -324,7 +327,7 @@ contract ValidatorManager is ISemver, IValidatorManager {
             }
         } else {
             // If output is already rewarded, add slashing asset to the winner's asset directly.
-            ASSET_MANAGER.modifyBalanceWithChallenge(winner, challengeReward, false);
+            ASSET_MANAGER.increaseBalanceWithChallenge(winner, challengeReward);
             updateValidatorTree(winner, false);
 
             emit ChallengeRewardDistributed(outputIndex, winner, challengeReward);
@@ -530,7 +533,7 @@ contract ValidatorManager is ISemver, IValidatorManager {
 
                 uint128 challengeReward = _pendingChallengeReward[outputIndex];
                 if (challengeReward > 0) {
-                    ASSET_MANAGER.modifyBalanceWithChallenge(submitter, challengeReward, false);
+                    ASSET_MANAGER.increaseBalanceWithChallenge(submitter, challengeReward);
                     delete _pendingChallengeReward[outputIndex];
 
                     emit ChallengeRewardDistributed(outputIndex, submitter, challengeReward);

--- a/packages/contracts/contracts/L1/ValidatorManager.sol
+++ b/packages/contracts/contracts/L1/ValidatorManager.sol
@@ -314,9 +314,9 @@ contract ValidatorManager is ISemver, IValidatorManager {
      * @inheritdoc IValidatorManager
      */
     function slash(uint256 outputIndex, address winner, address loser) external onlyColosseum {
-        (uint128 tax, uint128 challengeReward) = ASSET_MANAGER.decreaseBalanceWithChallenge(loser);
+        uint128 challengeReward = ASSET_MANAGER.decreaseBalanceWithChallenge(loser);
 
-        emit Slashed(outputIndex, loser, tax + challengeReward);
+        emit Slashed(outputIndex, loser, challengeReward);
 
         _sendToJail(loser);
 
@@ -327,7 +327,7 @@ contract ValidatorManager is ISemver, IValidatorManager {
             }
         } else {
             // If output is already rewarded, add slashing asset to the winner's asset directly.
-            ASSET_MANAGER.increaseBalanceWithChallenge(winner, challengeReward);
+            challengeReward = ASSET_MANAGER.increaseBalanceWithChallenge(winner, challengeReward);
             updateValidatorTree(winner, false);
 
             emit ChallengeRewardDistributed(outputIndex, winner, challengeReward);
@@ -533,7 +533,10 @@ contract ValidatorManager is ISemver, IValidatorManager {
 
                 uint128 challengeReward = _pendingChallengeReward[outputIndex];
                 if (challengeReward > 0) {
-                    ASSET_MANAGER.increaseBalanceWithChallenge(submitter, challengeReward);
+                    challengeReward = ASSET_MANAGER.increaseBalanceWithChallenge(
+                        submitter,
+                        challengeReward
+                    );
                     delete _pendingChallengeReward[outputIndex];
 
                     emit ChallengeRewardDistributed(outputIndex, submitter, challengeReward);

--- a/packages/contracts/contracts/L1/interfaces/IValidatorManager.sol
+++ b/packages/contracts/contracts/L1/interfaces/IValidatorManager.sol
@@ -306,6 +306,14 @@ interface IValidatorManager {
     function bondValidatorKro(address validator) external;
 
     /**
+     * @notice Call ASSET_MANAGER.unbondValidatorKro(). This function is only called by the
+     *         Colosseum contract.
+     *
+     * @param validator Address of the validator.
+     */
+    function unbondValidatorKro(address validator) external;
+
+    /**
      * @notice Slash KRO from the vault of the challenge loser and move the slashing asset to
      *         pending challenge reward before output rewarded, after directly to winner's asset.
      *         Since the behavior could threaten the security of the chain, the loser is sent to

--- a/packages/contracts/contracts/L1/interfaces/IValidatorManager.sol
+++ b/packages/contracts/contracts/L1/interfaces/IValidatorManager.sol
@@ -199,6 +199,15 @@ interface IValidatorManager {
     event Slashed(uint256 indexed outputIndex, address indexed loser, uint128 amount);
 
     /**
+     * @notice Emitted when the slash is reverted.
+     *
+     * @param outputIndex Index of the L2 checkpoint output.
+     * @param loser       Address of the challenge original loser.
+     * @param amount      The amount of KRO refunded to the loser.
+     */
+    event SlashReverted(uint256 indexed outputIndex, address indexed loser, uint128 amount);
+
+    /**
      * @notice Reverts when caller is not allowed.
      */
     error NotAllowedCaller();

--- a/packages/contracts/contracts/L1/interfaces/IValidatorManager.sol
+++ b/packages/contracts/contracts/L1/interfaces/IValidatorManager.sol
@@ -289,13 +289,12 @@ interface IValidatorManager {
     function finalizeCommissionChange() external;
 
     /**
-     * @notice Attempts to unjail a validator. Only Colosseum can set force to true, otherwise only
-     *         the validator who wants to unjail can call it.
+     * @notice Attempts to unjail a validator. Only the validator who wants to unjail can call
+     *         itself.
      *
      * @param validator Address of the validator.
-     * @param force     To unjail forcefully or not.
      */
-    function tryUnjail(address validator, bool force) external;
+    function tryUnjail(address validator) external;
 
     /**
      * @notice Call ASSET_MANAGER.bondValidatorKro(). This function is only called by the Colosseum
@@ -324,6 +323,14 @@ interface IValidatorManager {
      * @param loser       Address of the challenge loser.
      */
     function slash(uint256 outputIndex, address winner, address loser) external;
+
+    /**
+     * @notice Revert slash. This function is only called by the Colosseum contract.
+     *
+     * @param outputIndex The index of output challenged.
+     * @param loser       Address of the challenge loser.
+     */
+    function revertSlash(uint256 outputIndex, address loser) external;
 
     /**
      * @notice Updates the validator tree.


### PR DESCRIPTION
# Description

Unbond validator KRO during output finalization and slashing.

Additionally, there is a point to consider related to challenge process. I wanna discuss about the way to handle it, which I implemented in 83f1908c1a3e5f01a6659dd6c28d61ca79ae43a1.

When a malicious challenger successfully proved fault due to a ZK bug, the asserter will be slashed and not have bond anymore. But after challenge dismissed by security council, the output submitter is reverted to the asserter and the asserter's asset will be tried to be unbonded when output being finalized. In that case, the asserter does not have bond since it has been slashed, so output finalization will be reverted.

I made a change to replace the output submitter to security council when dismissing challenge, and block proving fault when submitter is security council because the output has already been validated by security council.

Please share your thoughts about the solution is appropriate or not.