### PR TITLE
feat: modify validator client for validator system V2

### DIFF
--- a/kroma-validator/challenger.go
+++ b/kroma-validator/challenger.go
@@ -600,22 +600,17 @@ func (c *Challenger) handleChallenge(outputIndex *big.Int, asserter common.Addre
 
 			// if challenger
 			if isChallenger && c.cfg.ChallengerEnabled {
-				if isOutputDeleted {
-					// if output has been already deleted, cancel challenge to refund pending bond
-					if status != chal.StatusChallengerTimeout {
-						tx, err := c.CancelChallenge(c.ctx, outputIndex)
-						if err != nil {
-							c.log.Error("failed to create cancel challenge tx", "err", err, "outputIndex", outputIndex)
-							continue
-						}
-						if err := c.submitChallengeTx(tx); err != nil {
-							c.log.Error("failed to submit cancel challenge tx", "err", err, "outputIndex", outputIndex)
-							continue
-						}
+				// if output has been already deleted, cancel challenge to refund challenger's bond
+				if isOutputDeleted && status != chal.StatusChallengerTimeout {
+					tx, err := c.CancelChallenge(c.ctx, outputIndex)
+					if err != nil {
+						c.log.Error("failed to create cancel challenge tx", "err", err, "outputIndex", outputIndex)
+						continue
 					}
-					// if output has been already deleted, terminate handling
-					c.log.Info("output is already deleted when handling challenge", "outputIndex", outputIndex)
-					return
+					if err := c.submitChallengeTx(tx); err != nil {
+						c.log.Error("failed to submit cancel challenge tx", "err", err, "outputIndex", outputIndex)
+						continue
+					}
 				}
 
 				// if output is already finalized, terminate handling

--- a/kroma-validator/config.go
+++ b/kroma-validator/config.go
@@ -3,7 +3,6 @@ package validator
 import (
 	"context"
 	"errors"
-	"math/big"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -11,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
-	"github.com/ethereum-optimism/optimism/op-service/optsutils"
 	pprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -21,7 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
 
-	"github.com/kroma-network/kroma/kroma-bindings/bindings"
 	chal "github.com/kroma-network/kroma/kroma-validator/challenge"
 	"github.com/kroma-network/kroma/kroma-validator/flags"
 	"github.com/kroma-network/kroma/kroma-validator/metrics"
@@ -34,7 +31,6 @@ type Config struct {
 	ColosseumAddr                   common.Address
 	SecurityCouncilAddr             common.Address
 	ValidatorPoolAddr               common.Address
-	ValPoolTerminationIndex         *big.Int
 	ValidatorManagerAddr            common.Address
 	AssetManagerAddr                common.Address
 	ChallengerPollInterval          time.Duration
@@ -260,23 +256,11 @@ func NewValidatorConfig(cfg CLIConfig, l log.Logger, m metrics.Metricer) (*Confi
 		return nil, err
 	}
 
-	cCtx, cCancel := context.WithTimeout(ctx, time.Second*20)
-	defer cCancel()
-	valPoolContract, err := bindings.NewValidatorPoolCaller(valPoolAddress, l1Client)
-	if err != nil {
-		return nil, err
-	}
-	valPoolTerminationIndex, err := valPoolContract.TERMINATEOUTPUTINDEX(optsutils.NewSimpleCallOpts(cCtx))
-	if err != nil {
-		return nil, err
-	}
-
 	return &Config{
 		L2OutputOracleAddr:              l2OOAddress,
 		ColosseumAddr:                   colosseumAddress,
 		SecurityCouncilAddr:             securityCouncilAddress,
 		ValidatorPoolAddr:               valPoolAddress,
-		ValPoolTerminationIndex:         valPoolTerminationIndex,
 		ValidatorManagerAddr:            valMgrAddress,
 		AssetManagerAddr:                assetManagerAddress,
 		ChallengerPollInterval:          cfg.ChallengerPollInterval,

--- a/kroma-validator/metrics/metrics.go
+++ b/kroma-validator/metrics/metrics.go
@@ -30,7 +30,7 @@ type Metricer interface {
 	txmetrics.TxMetricer
 
 	RecordL2OutputSubmitted(l2ref eth.L2BlockRef)
-	RecordDepositAmount(amount *big.Int)
+	RecordUnbondedDepositAmount(amount *big.Int)
 	RecordValidatorStatus(status uint8)
 	RecordNextValidator(address common.Address)
 	RecordChallengeCheckpoint(outputIndex *big.Int)
@@ -45,12 +45,12 @@ type Metrics struct {
 	txmetrics.TxMetrics
 	opmetrics.RPCMetrics
 
-	Info                prometheus.GaugeVec
-	Up                  prometheus.Gauge
-	DepositAmount       prometheus.Gauge
-	ValidatorStatus     prometheus.Gauge
-	NextValidator       prometheus.GaugeVec
-	ChallengeCheckpoint prometheus.Gauge
+	Info                  prometheus.GaugeVec
+	Up                    prometheus.Gauge
+	UnbondedDepositAmount prometheus.Gauge
+	ValidatorStatus       prometheus.Gauge
+	NextValidator         prometheus.GaugeVec
+	ChallengeCheckpoint   prometheus.Gauge
 }
 
 var _ Metricer = (*Metrics)(nil)
@@ -85,10 +85,10 @@ func NewMetrics(procName string) *Metrics {
 			Name:      "up",
 			Help:      "1 if the kroma-validator has finished starting up",
 		}),
-		DepositAmount: factory.NewGauge(prometheus.GaugeOpts{
+		UnbondedDepositAmount: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
-			Name:      "deposit_amount",
-			Help:      "The amount deposited into the ValidatorPool contract",
+			Name:      "unbonded_deposit_amount",
+			Help:      "The amount of Validator balance excluding the bonded amount",
 		}),
 		ValidatorStatus: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
@@ -142,9 +142,9 @@ func (m *Metrics) RecordL2OutputSubmitted(l2ref eth.L2BlockRef) {
 	m.RecordL2Ref(L2OutputSubmitted, l2ref)
 }
 
-// RecordDepositAmount sets the amount deposited into the ValidatorPool contract.
-func (m *Metrics) RecordDepositAmount(amount *big.Int) {
-	m.DepositAmount.Set(opmetrics.WeiToEther(amount))
+// RecordUnbondedDepositAmount sets the amount deposited into the ValidatorPool contract.
+func (m *Metrics) RecordUnbondedDepositAmount(amount *big.Int) {
+	m.UnbondedDepositAmount.Set(opmetrics.WeiToEther(amount))
 }
 
 // RecordValidatorStatus sets the status of validator in the ValidatorManager contract.

--- a/kroma-validator/metrics/noop.go
+++ b/kroma-validator/metrics/noop.go
@@ -21,7 +21,7 @@ func (*noopMetrics) RecordInfo(version string) {}
 func (*noopMetrics) RecordUp()                 {}
 
 func (*noopMetrics) RecordL2OutputSubmitted(l2ref eth.L2BlockRef)   {}
-func (*noopMetrics) RecordDepositAmount(amount *big.Int)            {}
+func (*noopMetrics) RecordUnbondedDepositAmount(amount *big.Int)    {}
 func (*noopMetrics) RecordValidatorStatus(status uint8)             {}
 func (*noopMetrics) RecordNextValidator(address common.Address)     {}
 func (*noopMetrics) RecordChallengeCheckpoint(outputIndex *big.Int) {}

--- a/op-e2e/actions/l2_validator.go
+++ b/op-e2e/actions/l2_validator.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	kcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/optsutils"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum"
@@ -69,16 +68,9 @@ func NewL2Validator(t Testing, log log.Logger, cfg *ValidatorCfg, l1 *ethclient.
 	rollupConfig, err := rollupCl.RollupConfig(t.Ctx())
 	require.NoError(t, err)
 
-	valPoolContract, err := bindings.NewValidatorPoolCaller(cfg.ValidatorPoolAddr, l1)
-	require.NoError(t, err)
-
-	valPoolTerminationIndex, err := valPoolContract.TERMINATEOUTPUTINDEX(optsutils.NewSimpleCallOpts(t.Ctx()))
-	require.NoError(t, err)
-
 	validatorCfg := validator.Config{
 		L2OutputOracleAddr:              cfg.OutputOracleAddr,
 		ValidatorPoolAddr:               cfg.ValidatorPoolAddr,
-		ValPoolTerminationIndex:         valPoolTerminationIndex,
 		ValidatorManagerAddr:            cfg.ValidatorManagerAddr,
 		AssetManagerAddr:                cfg.AssetManagerAddr,
 		ColosseumAddr:                   cfg.ColosseumAddr,

--- a/packages/contracts/contracts/L1/AssetManager.sol
+++ b/packages/contracts/contracts/L1/AssetManager.sol
@@ -255,6 +255,17 @@ contract AssetManager is ISemver, IERC721Receiver, IAssetManager {
     }
 
     /**
+     * @notice Returns the total amount of validator balance excluding the bond amount.
+     *
+     * @param validator Address of the validator.
+     *
+     * @return The total amount of validator balance excluding the bond amount.
+     */
+    function totalValidatorBalance(address validator) external view returns (uint128) {
+        return _vaults[validator].asset.validatorKro - _vaults[validator].asset.validatorKroBonded;
+    }
+
+    /**
      * @notice Returns the reflective weight of given validator.
      *
      * @param validator Address of the validator.

--- a/packages/contracts/contracts/L1/AssetManager.sol
+++ b/packages/contracts/contracts/L1/AssetManager.sol
@@ -255,13 +255,9 @@ contract AssetManager is ISemver, IERC721Receiver, IAssetManager {
     }
 
     /**
-     * @notice Returns the total amount of validator balance excluding the bond amount.
-     *
-     * @param validator Address of the validator.
-     *
-     * @return The total amount of validator balance excluding the bond amount.
+     * @inheritdoc IAssetManager
      */
-    function totalValidatorBalance(address validator) external view returns (uint128) {
+    function totalValidatorKroNotBonded(address validator) external view returns (uint128) {
         return _vaults[validator].asset.validatorKro - _vaults[validator].asset.validatorKroBonded;
     }
 

--- a/packages/contracts/contracts/L1/interfaces/IAssetManager.sol
+++ b/packages/contracts/contracts/L1/interfaces/IAssetManager.sol
@@ -278,6 +278,15 @@ interface IAssetManager {
     function totalValidatorKroBonded(address validator) external view returns (uint128);
 
     /**
+     * @notice Returns the total amount of validator balance excluding the bond amount.
+     *
+     * @param validator Address of the validator.
+     *
+     * @return The total amount of validator balance excluding the bond amount.
+     */
+    function totalValidatorKroNotBonded(address validator) external view returns (uint128);
+
+    /**
      * @notice Returns the total amount of KRO that delegated by the delegators and accumulated as
      *         KRO delegation reward.
      *


### PR DESCRIPTION
# Description

Moved termination index from config to each components (`l2_output_submitter` / `challenger`), and added a check for bond amount at validator system v2. For this purpose, I added a view function which returns the balance of validator excluding the bond at AssetManager contract.
