### PR TITLE
feat: increase deployment gas limit for GasPriceOracleMPT

### DIFF
--- a/op-node/rollup/derive/kromampt_upgrade_transactions.go
+++ b/op-node/rollup/derive/kromampt_upgrade_transactions.go
@@ -240,7 +240,7 @@ func KromaMPTNetworkUpgradeTransactions(chainID *big.Int) ([]hexutil.Bytes, erro
 		To:                  nil,
 		Mint:                big.NewInt(0),
 		Value:               big.NewInt(0),
-		Gas:                 1_000_000,
+		Gas:                 1_500_000,
 		IsSystemTransaction: false,
 		Data:                gasPriceOracleMPTDeploymentBytecode,
 	}).MarshalBinary()

--- a/op-node/rollup/derive/kromampt_upgrade_transactions_test.go
+++ b/op-node/rollup/derive/kromampt_upgrade_transactions_test.go
@@ -146,7 +146,7 @@ func TestMPTNetworkTransactions(t *testing.T) {
 		require.Equal(t, deployGasPriceOracleSender, GasPriceOracleMPTDeployerAddress)
 		require.Equal(t, deployGasPriceOracleMPTSource.SourceHash(), deployGasPriceOracle.SourceHash())
 		require.Nil(t, deployGasPriceOracle.To())
-		require.Equal(t, uint64(1_000_000), deployGasPriceOracle.Gas())
+		require.Equal(t, uint64(1_500_000), deployGasPriceOracle.Gas())
 		require.Equal(t, hexutil.Bytes(gasPriceOracleMPTDeploymentBytecode).String(), hexutil.Bytes(deployGasPriceOracle.Data()).String())
 
 		updateL1BlockProxySender, updateL1BlockProxy := toDepositTxn(t, upgradeTxns[5])


### PR DESCRIPTION
# Description

Increase the deployment gas limit value of the gasPriceOracle(MPT) contract included in the MPT upgrade. 

The actual gas consumption is around 1.2 million.