### PR TITLE
feat: delay sequencer action if migration is not completed

### DIFF
--- a/op-node/rollup/driver/sequencer.go
+++ b/op-node/rollup/driver/sequencer.go
@@ -157,6 +157,13 @@ func (d *Sequencer) PlanNextSequencerAction() time.Duration {
 		return delay
 	}
 
+	// [Kroma: START]
+	// Delay if the next block to be created is a KromaMPT block.
+	if d.rollupCfg.IsKromaMPTParentBlock(head.Time) {
+		return d.nextAction.Sub(now)
+	}
+	// [Kroma: END]
+
 	blockTime := time.Duration(d.rollupCfg.BlockTime) * time.Second
 	payloadTime := time.Unix(int64(head.Time+d.rollupCfg.BlockTime), 0)
 	remainingTime := payloadTime.Sub(now)

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -391,10 +391,12 @@ func (s *Driver) eventLoop() {
 				s.metrics.RecordPipelineReset()
 				continue
 			} else if err != nil && errors.Is(err, derive.ErrTemporary) {
+				// [Kroma: START]
 				if strings.Contains(err.Error(), core.ErrHaltOnStateTransition.Error()) {
 					s.log.Warn("Stopping derivation pipeline", "reason", err)
 					return
 				}
+				// [Kroma: END]
 				s.log.Warn("Derivation process temporary error", "attempts", stepAttempts, "err", err)
 				reqStep()
 				continue


### PR DESCRIPTION
The CI failures in previous PRs were suspected to be caused by system performance degradation due to continuous log output from the migrator. 
To fix it, I added a delay 1 second before calling the next engine API when the migration is not completed.
