### PR TITLE
feat(contracts): enable build info in foundry settings

### DIFF
--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -18,8 +18,9 @@ remappings = [
   'forge-std/=node_modules/forge-std/src',
   'ds-test/=node_modules/ds-test/src'
 ]
+extra_output = ['metadata']
+build_info = true
 # [Kroma: END]
-extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 bytecode_hash = 'none'
 build_info_path = 'artifacts/build-info'
 


### PR DESCRIPTION
# Description

To verify deployed contracts, enable build info(esp metadata) in foundry settings.
