### PR TITLE
feat: ignore KromaMPT block payload

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -594,6 +594,13 @@ func (n *OpNode) OnUnsafeL2Payload(ctx context.Context, from peer.ID, envelope *
 		return nil
 	}
 
+	// [Kroma: START]
+	if n.runCfg.rollupCfg.IsKromaMPTActivationBlock(uint64(envelope.ExecutionPayload.Timestamp)) {
+		n.log.Info("Received the payload of the KromaMPT block from p2p but ignored it", "id", envelope.ExecutionPayload.ID(), "peer", from)
+		return nil
+	}
+	// [Kroma: END]
+
 	n.tracer.OnUnsafeL2Payload(ctx, from, envelope)
 
 	n.log.Info("Received signed execution payload from p2p", "id", envelope.ExecutionPayload.ID(), "peer", from)

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -371,6 +371,14 @@ func (c *Config) IsKromaMPT(timestamp uint64) bool {
 	return c.KromaMPTTime != nil && timestamp >= *c.KromaMPTTime
 }
 
+// IsKromaMPTActivationBlock returns whether the specified block is the first block subject to the
+// KromaMPT upgrade. KromaMPT activation at genesis does not count.
+func (c *Config) IsKromaMPTActivationBlock(l2BlockTime uint64) bool {
+	return c.IsKromaMPT(l2BlockTime) &&
+		l2BlockTime >= c.BlockTime &&
+		!c.IsKromaMPT(l2BlockTime-c.BlockTime)
+}
+
 // IsKromaMPTParentBlock returns whether the specified block is the parent block subject to the
 // KromaMPT upgrade. KromaMPT activation at genesis does not count.
 func (c *Config) IsKromaMPTParentBlock(l2BlockTime uint64) bool {


### PR DESCRIPTION
# Description

Prevents KromaMPT block from being handled as unsafe payload over P2P. 
This ensures that nodes can continue the migration process, even if they receive a new unsafe payload from the sequencer before receiving the batch containing the KromaMPT parent block, allowing them to still process the safe attribute.
