### PR TITLE
Fix Grammar and Typos in Comments and Documentation

### DIFF
--- a/op-e2e/bridge_test.go
+++ b/op-e2e/bridge_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kroma-network/kroma/kroma-bindings/predeploys"
 )
 
-// TestERC20BridgeDeposits tests the the L1StandardBridge bridge ERC20
+// TestERC20BridgeDeposits tests the L1StandardBridge bridge ERC20
 // functionality.
 func TestERC20BridgeDeposits(t *testing.T) {
 	InitParallel(t)

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -376,7 +376,7 @@ func TestTxMgrConfirmAtMinGasPrice(t *testing.T) {
 }
 
 // TestTxMgrNeverConfirmCancel asserts that a Send can be canceled even if no
-// transaction is mined. This is done to ensure the the tx mgr can properly
+// transaction is mined. This is done to ensure the tx mgr can properly
 // abort on shutdown, even if a txn is in the process of being published.
 func TestTxMgrNeverConfirmCancel(t *testing.T) {
 	t.Parallel()

--- a/packages/contracts/scripts/go-ffi/README.md
+++ b/packages/contracts/scripts/go-ffi/README.md
@@ -31,7 +31,7 @@ function myFFITest() public {
 
 ### Available Modes
 
-There are two modes available in `go-ffi`: `diff` and `trie`. Each are present as a subcommand to the `go-ffi` binary, with their own set of variants.
+There are two modes available in `go-ffi`: `diff` and `trie`. Each is present as a subcommand to the `go-ffi` binary, with their own set of variants.
 
 #### `diff`
 


### PR DESCRIPTION

Fixed the following issues:

1. op-service/txmgr/txmgr_test.go:
Old: "tests the the L1StandardBridge"
New: "tests the L1StandardBridge"
Reason: Removed duplicate word "the"

2. op-service/txmgr/txmgr_test.go:
Old: "ensure the the tx mgr"
New: "ensure the tx mgr"
Reason: Removed duplicate word "the"

3. packages/contracts/scripts/go-ffi/README.md:
Old: "Each are present"
New: "Each is present" 
Reason: Fixed subject-verb agreement with singular "Each"

These changes improve readability and grammar without affecting functionality.
