### PR TITLE
chore: update main.go

### DIFF
--- a/kroma-bindings/gen/main.go
+++ b/kroma-bindings/gen/main.go
@@ -53,11 +53,11 @@ func main() {
 
 	contractData, err := os.ReadFile(f.Contracts)
 	if err != nil {
-		log.Fatal("error reading contract list: %w\n", err)
+		log.Fatalf("error reading contract list: %w\n", err)
 	}
 	contracts := []string{}
 	if err := json.Unmarshal(contractData, &contracts); err != nil {
-		log.Fatal("error parsing contract list: %w\n", err)
+		log.Fatalf("error parsing contract list: %w\n", err)
 	}
 
 	sourceMaps := strings.Split(f.SourceMaps, ",")


### PR DESCRIPTION
Changed log.Fatal to log.Fatalf in kroma-bindings/gen/main.go where string formatting is used:

- log.Fatal("error reading contract list: %w\n", err)
+ log.Fatalf("error reading contract list: %w\n", err)

- log.Fatal("error parsing contract list: %w\n", err) 
+ log.Fatalf("error parsing contract list: %w\n", err)

Reason: When using format specifiers (%w, %v, etc.), log.Fatalf must be used instead of log.Fatal to properly format the error messages. This ensures correct error reporting and debugging.

Note: log.Fatal("must provide -monorepo-base") remains unchanged as it doesn't use format specifiers.