### PR TITLE
chore: Fix incorrect type for Votes Update governancetoken.go

### DIFF
--- a/kroma-bindings/bindings/governancetoken.go
+++ b/kroma-bindings/bindings/governancetoken.go
@@ -32,7 +32,7 @@ var (
 // ERC20VotesCheckpoint is an auto generated low-level Go binding around an user-defined struct.
 type ERC20VotesCheckpoint struct {
 	FromBlock uint32
-	Votes     *big.Int
+	Votes     uint224
 }
 
 // GovernanceTokenMetaData contains all meta data concerning the GovernanceToken contract.


### PR DESCRIPTION
# Description

I noticed a type mismatch in the `ERC20VotesCheckpoint` struct. The `Votes` field was defined as `*big.Int`, but according to the ABI contract, it should be `uint224`. This discrepancy could cause issues when interacting with the contract.  

I’ve updated the struct to use `uint224` for the `Votes` field to align with the ABI specification. This should resolve any potential errors related to type mismatches.  
