### PR TITLE
fix: fix incorrect error logging format

### DIFF
--- a/kroma-validator/validator.go
+++ b/kroma-validator/validator.go
@@ -54,7 +54,7 @@ func Main(version string, cliCtx *cli.Context) error {
 	}
 	defer func() {
 		if err = server.Stop(); err != nil {
-			l.Error("Error shutting down http server: %w", err)
+			l.Error("Error shutting down http server", "err", err)
 		}
 	}()
 


### PR DESCRIPTION
# Description

The `l.Error` method from the `log` package doesn't support the `%w` formatting verb. This causes `%w` to be logged as a literal string instead of wrapping the error. I've updated the code to use the correct formatting for logging errors with `log.Logger`. This ensures errors are logged properly without losing context.  