### PR TITLE
chore: Fix incorrect error message in Update main.go

### DIFF
--- a/kroma-chain-ops/cmd/check-kroma-mpt/main.go
+++ b/kroma-chain-ops/cmd/check-kroma-mpt/main.go
@@ -326,7 +326,7 @@ func checkL1BlockAddrAndData(ctx context.Context, env *actionEnv) error {
 		return fmt.Errorf("l1 info tx data length not matched before MPT, expected: %d, got: %d", derive.L1InfoEcotoneLen, len(prevL1InfoTx.Data()))
 	}
 	if len(mptL1InfoTx.Data()) != derive.L1InfoKromaMPTLen {
-		return fmt.Errorf("l1 info tx data length not matched before MPT, expected: %d, got: %d", derive.L1InfoKromaMPTLen, len(mptL1InfoTx.Data()))
+		return fmt.Errorf("l1 info tx data length not matched after MPT, expected: %d, got: %d", derive.L1InfoKromaMPTLen, len(mptL1InfoTx.Data()))
 	}
 
 	env.log.Info("L1Block address and tx data test: SUCCESS")


### PR DESCRIPTION
# Description
  
I noticed a small but confusing typo in the error message within the `checkL1BlockAddrAndData` function. The second check, which occurs *after* MPT, incorrectly states "before MPT" in its error message.

This PR fixes the error message to accurately reflect that the check happens *after* MPT.  