### PR TITLE
chore: fix typo in function name Update layer_one.go

### DIFF
--- a/kroma-chain-ops/genesis/layer_one.go
+++ b/kroma-chain-ops/genesis/layer_one.go
@@ -145,7 +145,7 @@ func PostProcessL1DeveloperGenesis(stateDB *state.MemoryStateDB, deployments *L1
 
 	// Change the key of _quorumNumeratorHistory in UpgradeGovernor to 1 which means that quorumNumerator has been set at L1 block number 1 for guardian test
 	if !stateDB.Exist(deployments.UpgradeGovernorProxy) {
-		return fmt.Errorf("upgardeGovernor proxy doesn't exist at %s", deployments.UpgradeGovernorProxy)
+		return fmt.Errorf("upgradeGovernor proxy doesn't exist at %s", deployments.UpgradeGovernorProxy)
 	}
 
 	slot, err = getStorageSlot("UpgradeGovernor", "_quorumNumeratorHistory")


### PR DESCRIPTION
# Description

<img width="815" alt="Снимок экрана 2025-01-25 в 21 36 21" src="https://github.com/user-attachments/assets/fe64ed81-5e47-4099-a1b3-10ec8bae9699" />

A typo in the function name `upgardeGovernor`.
PR corrects it to `upgradeGovernor` to ensure consistency and accuracy in the codebase.
