### PR TITLE
Fix Grammar and Documentation Issues

### DIFF
--- a/kroma-chain-ops/cmd/check-kroma-mpt/main.go
+++ b/kroma-chain-ops/cmd/check-kroma-mpt/main.go
@@ -272,7 +272,7 @@ func checkFeeDistribution(ctx context.Context, env *actionEnv) error {
 			return err
 		}
 		if increaseRequired != (bal.Cmp(prevBal) == 1) {
-			return fmt.Errorf("fee distribution unexpectedly, expected increasing: %t, but account: %s, prev: %d, after: %d",
+			return fmt.Errorf("fee distribution unexpected, expected increasing: %t, but account: %s, prev: %d, after: %d",
 				increaseRequired, addr, prevBal, bal)
 		}
 		return nil

--- a/kroma-chain-ops/crossdomain/message_test.go
+++ b/kroma-chain-ops/crossdomain/message_test.go
@@ -40,7 +40,7 @@ func TestEncode(t *testing.T) {
 	})
 }
 
-// TestEncode tests the hash of a CrossDomainMessage. The assertion was
+// TestHash tests the hash of a CrossDomainMessage. The assertion was
 // created using solidity.
 func TestHash(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION

Changes:
1. kroma-chain-ops/cmd/check-kroma-mgt/main.go:
- "fee distribution unexpectedly"
+ "fee distribution unexpected"
Reason: Fixed grammatical error by using correct adjective form.

2. kroma-chain-ops/crossdomain/message_test.go:
- // TestEncode tests the hash of a CrossDomainMessage.
+ // TestHash tests the hash of a CrossDomainMessage.
Reason: Fixed incorrect function name in comment to match actual function.

