### PR TITLE
Add nil check for storage values in SetStorage function

### DIFF
--- a/kroma-chain-ops/state/state.go
+++ b/kroma-chain-ops/state/state.go
@@ -15,6 +15,9 @@ import (
 // SetStorage will set the storage values in a db given a contract name,
 // address and the storage values
 func SetStorage(name string, address common.Address, values opstate.StorageValues, db vm.StateDB) error {
+    if values == nil {
+        return fmt.Errorf("%s: storage values cannot be nil", name)
+    }
 	layout, err := bindings.GetStorageLayout(name)
 	if err != nil {
 		return fmt.Errorf("cannot set storage: %w", err)


### PR DESCRIPTION


Changes:
- Added nil check validation in kroma-chain-ops/state/state.go
- Added error message for nil values parameter

Why:
- Prevents potential panic from nil values
- Provides early error detection with clear message
- Follows Go best practices for defensive programming
- No functional changes, only validation improvement

Testing:
- Verified with nil values for error handling
- Verified with valid values for normal operation