### PR TITLE
feat(validator): remove check SP1 version

### DIFF
--- a/kroma-validator/config.go
+++ b/kroma-validator/config.go
@@ -275,16 +275,13 @@ func NewValidatorConfig(cfg CLIConfig, l log.Logger, m metrics.Metricer) (*Confi
 			}
 			witnessGenerator = chal.NewWitnessGenerator(wc)
 
-			proverSpec, err := zkVMProofFetcher.Spec(ctx)
+			_, err = zkVMProofFetcher.Spec(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to request spec of zkVM prover: %w", err)
 			}
-			witnessGenSpec, err := witnessGenerator.Spec(ctx)
+			_, err = witnessGenerator.Spec(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to request spec of witness generator: %w", err)
-			}
-			if proverSpec.SP1Version != witnessGenSpec.SP1Version {
-				return nil, errors.New("SP1 version of zkVM prover and witness generator mismatched")
 			}
 		} else {
 			clientOpt := rpc.WithHTTPClient(&http.Client{


### PR DESCRIPTION
# Description

The reference SP1 version of prover proxy and witness generator can be different. So removed the comparison between them when initializing validator.
