### PR TITLE
docs: fix typos in comments and Logs

### DIFF
--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -575,7 +575,7 @@ func (oc *OpConductor) action() {
 			break
 		}
 
-		// 2. we're here becasuse an healthy leader became unhealthy itself
+		// 2. we're here because an healthy leader became unhealthy itself
 		//    then we should try to stop sequencing locally and transfer leadership.
 		var result *multierror.Error
 		// Try to stop sequencer first, but since sequencer is not healthy, we may not be able to stop it.

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -451,7 +451,7 @@ export abstract class BaseServiceV2<
     this.logger.info('waiting for main to complete')
     // if main is in the middle of running wait for it to complete
     await this.mainPromise
-    this.logger.info('main loop stoped.')
+    this.logger.info('main loop stopped.')
 
     // Shut down the metrics server if it's running.
     if (this.server) {


### PR DESCRIPTION

### Description
This pull request addresses minor typographical errors in the codebase:

1. **Go File (`op-conductor/conductor/service.go`):**
   - Corrected the comment from "becasuse" to "because".

2. **TypeScript File (`packages/common-ts/src/base-service/base-service-v2.ts`):**
   - Fixed the log message typo from "stoped" to "stopped".

These changes improve the readability and professionalism of the code comments and logs.

